### PR TITLE
cockpituous: Enable github and COPR releases

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -6,11 +6,10 @@
 # order to complete its work.
 
 RELEASE_SOURCE="_release/source"
-RELEASE_SPEC="cockpit-starter-kit.spec"
+RELEASE_SPEC="cockpit-ostree.spec"
 RELEASE_SRPM="_release/srpm"
 
 job release-source
 job release-srpm
-# job release-github
-# job release-copr @myorg/myrepo
-# check cockpituous documentation for available release targets
+job release-github
+job release-copr @cockpit/cockpit-preview


### PR DESCRIPTION
Also fix `RELEASE_SPEC`, it still had the starter-kit default.

---

I tested this with cockpituous' release-runner in dry-run mode:
```
❱❱❱ ~/upstream/cockpituous/release/release-runner -n -t 173 ./cockpituous-release 
> Starting: release-source
> Committing first tarball
> Done: release-source
> Starting: release-srpm
> Updating spec file
> Copying sources
> Building SRPM
> Done: release-srpm
> Starting: release-github
> Creating release draft: 173
> Uploading file: _release/source/cockpit-ostree-173.tar.gz
############################################################################################################################################################ 100,0%
> Ready: release-github
> Starting: release-copr @cockpit/cockpit-preview
> Validating ~/.config/copr
release-copr: ~/.config/copr is expired, please renew
release-runner: failed code 1: release-copr @cockpit/cockpit-preview

❱❱❱ ls -lR _release/
_release/:
total 628
-rw-rw-r-- 1 martin martin 631572 19. Jul 10:09 cockpit-ostree-173-2.fc28.src.rpm
drwxrwxr-x 1 martin martin    208 19. Jul 10:08 source
lrwxrwxrwx 1 martin martin     33 19. Jul 10:09 srpm -> cockpit-ostree-173-2.fc28.src.rpm

_release/source:
total 620
-rw-rw-r-- 1 martin martin 624570 19. Jul 10:08 cockpit-ostree-173.tar.gz
```

It got as far as expected, and I got a valid "173 draft release" on GitHub. So this should work. Once this lands, I'll push a 173 release for real and release it through Cockpituous.

*NOTE*: The *-2* release is wrong -- this gets fixed in https://github.com/cockpit-project/cockpituous/pull/194 . I'll get that fix into our infrastructure.