### PR TITLE
test: Force running ws container

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -6,7 +6,7 @@ set -eux
 atomic install cockpit/ws
 # don't force https:// (self-signed cert)
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
-atomic run cockpit/ws
+atomic --ignore run cockpit/ws
 
 # create a local repository for tests
 mkdir -p /var/local-repo


### PR DESCRIPTION
Occasionally the VM install fails like this:

```
+ atomic run cockpit/ws
The image 'ws' appears to have not been installed and has an INSTALL label.  You should install this image first.  Re-run with --ignore to bypass this error.
Command '/var/tmp/vm.install' returned non-zero exit status 1.
```

We do run `atomic install`, this seems to be a race condition in Fedora
Atomic. Skip that check, we are not testing `atomic` itself here.