### PR TITLE
Simplify spec file

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -17,14 +17,10 @@ Cockpit component for managing software updates for ostree based systems.
 %prep
 %setup -n cockpit-ostree
 
-%build
-# There is nothing to do, release tarballs already have dist/.
-
 %install
-make install DESTDIR=%{buildroot}
-find %{buildroot} -type f >> files.list
-sed -i "s|%{buildroot}||" *.list
+%make_install
 
-%files -f files.list
+%files
+/usr/share/cockpit/*
 
 %changelog


### PR DESCRIPTION
- Entirely drop `%build` section, as there is nothing to do anyway.
- Use `%make_install` macro.
- Replace the complicated file list wrangling with a simple directory
  enumeration.

Thanks to Igor Gnatenko for the suggestions!

See https://bugzilla.redhat.com/show_bug.cgi?id=1603146