### PR TITLE
Spec: Use %{_datadir}

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -22,6 +22,6 @@ Cockpit component for managing software updates for ostree based systems.
 %make_install
 
 %files
-/usr/share/cockpit/*
+%{_datadir}/cockpit/*
 
 %changelog


### PR DESCRIPTION
This was already done in starter-kit, but forgotten when merging the
change.