### PR TITLE
Drop python3 build requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGE_NAME := $(shell python3 -c "import json; print(json.load(open('package.json'))['name'])")
+PACKAGE_NAME := cockpit-ostree
 VERSION := $(shell git describe 2>/dev/null || echo 1)
 ifeq ($(TEST_OS),)
 TEST_OS = fedora-atomic

--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -2,7 +2,6 @@ Name: cockpit-ostree
 Version: @VERSION@
 Release: 1%{?dist}
 BuildArch: noarch
-BuildRequires: /usr/bin/python3
 Summary: Cockpit user interface for rpm-ostree
 License: LGPLv2.1+
 Requires: cockpit-bridge >= 125


### PR DESCRIPTION
Hardcode the package name instead of parsing it from package.json. It
won't change for cockpit-ostree, this was a leftover from starter-kit.