### PR TITLE
Drop source map

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -20,6 +20,9 @@ Cockpit component for managing software updates for ostree based systems.
 %install
 %make_install
 
+# drop source maps, they are large and just for debugging
+find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs rm --verbose
+
 %files
 %{_datadir}/cockpit/*
 


### PR DESCRIPTION
They are large and just for debugging. If they are ever needed, they
should move into a separate -debugsource package, but this seems a bit
overkill here.

This reduces the rpm from 680 to 180 kB.