### PR TITLE
Add packit configuration

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,0 +1,8 @@
+specfile_path: cockpit-ostree.spec
+synced_files:
+  - cockpit-ostree.spec
+upstream_project_name: cockpit-ostree
+downstream_package_name: cockpit-ostree
+actions:
+  post-upstream-clone: make cockpit-ostree.spec
+  create-archive: make dist-gzip


### PR DESCRIPTION
See <https://packit.dev>. This will gradually replace our cockpituous
configuration.