### PR TITLE
Bump css-loader to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chrome-remote-interface": "^0.25.5",
     "compression-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.0.3",
-    "css-loader": "^0.28.11",
+    "css-loader": "^3.0.0",
     "eslint": "^6.0.1",
     "eslint-config-standard": "^13.0.0",
     "eslint-loader": "^2.2.0",


### PR DESCRIPTION
This also updates to a newer js-yaml, which addresses the current two
`npm audit` issues:

  - https://npmjs.com/advisories/788
  - https://npmjs.com/advisories/813