### PR TITLE
package.json: Bump version of less-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "less": "^3.0.4",
-    "less-loader": "^4.1.0",
+    "less-loader": "^5.0.0",
     "po2json": "^0.4.5",
     "sizzle": "^2.3.3",
     "stdio": "^0.2.7",


### PR DESCRIPTION
See https://github.com/less/less.js/issues/3414

No breaking changes for us were introduced. Also inspected that less is loaded correctly.