### PR TITLE
Drop less markers from *.css imports

### DIFF
--- a/src/ostree.less
+++ b/src/ostree.less
@@ -19,10 +19,10 @@
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-@import (less) "./page.css";
+@import "./page.css";
 @import "./listing.less";
-@import (less) "./timeline.css";
-@import (less) "./table.css";
+@import "./timeline.css";
+@import "./table.css";
 
 /* Used to hide angular elements until they are ready */
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {


### PR DESCRIPTION
less ≥ 3.11 will try to look for a <filename>.less (e. g.
"page.css.less") which does not exist.