### PR TITLE
Build rpm for continuous-atomic in centos-7

### DIFF
--- a/test/rpmbuild-local
+++ b/test/rpmbuild-local
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Take an srpm and build it locally. This  is sufficient for most "noarch" builds.
+set -eux
+
+SRPM="$1"
+
+if [ "${TEST_OS:-}" = rhel-atomic ]; then
+    MACRO_RHEL=7
+fi
+
+mkdir -p "`pwd`/output"
+mkdir -p "`pwd`/rpmbuild"
+rpmbuild --rebuild \
+  --define "_sourcedir `pwd`" \
+  --define "_specdir `pwd`" \
+  --define "_builddir `pwd`/rpmbuild" \
+  --define "_srcrpmdir `pwd`" \
+  --define "_rpmdir `pwd`/output" \
+  --define "_buildrootdir `pwd`/build" \
+  ${MACRO_RHEL:+--define "rhel $MACRO_RHEL"} \
+  "$SRPM"
+find `pwd`/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
+rm -r "`pwd`/rpmbuild"
+rm -r "`pwd`/output" "`pwd`/build"

--- a/test/rpmbuild-vm
+++ b/test/rpmbuild-vm
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+# Take an srpm and build it in the default mock environment of a given cockpit test VM image. This is necessary as
+# e. g. an rpm built on Fedora ≥ 31 cannot be installed on continuous-atomic any more due to a format change.
+
+import sys
+import argparse
+import os
+
+BOTS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "bots")
+sys.path.append(BOTS_DIR)
+
+from machine.machine_core import machine_virtual
+
+
+parser = argparse.ArgumentParser(description="Build rpm inside a cockpit test VM image")
+parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+parser.add_argument("srpm", help="path to SRPM")
+parser.add_argument("image", help="image name in which to build the SRPM")
+args = parser.parse_args()
+
+network = machine_virtual.VirtNetwork(0, image=args.image)
+machine = machine_virtual.VirtMachine(image=args.image, networking=network.host(), memory_mb=1024, verbose=args.verbose)
+machine.start()
+machine.wait_boot()
+machine.upload([args.srpm], "/tmp/", relative_dir=os.getcwd())
+
+machine.execute("su builder -c 'rm -rf /tmp/build-results; /usr/bin/mock --no-clean --resultdir /tmp/build-results "
+                "--rebuild /tmp/%s'" % os.path.basename(args.srpm), stdout=1)
+
+rpms = machine.execute("ls /tmp/build-results/*.rpm").strip().split()
+for rpm in rpms:
+    if args.verbose:
+        print("Downloading built rpm", rpm)
+    machine.download(rpm, os.getcwd())
+
+machine.stop()


### PR DESCRIPTION
Binary rpms (even `noarch`) built on Fedora ≥ 31 cannot be installed any
more into continuous-atomic's rpm-ostree, due to an RPM format change.

When testing continuous-atomic, build the srpm inside a centos-7 image.
Add a test/rpmbuild-vm script for that.

For symmetry, move the call for local rpm builds out into
test/rpmbuild-local, and use the srpm as well instead of the .spec.