### PR TITLE
Switch default TEST_OS to fedora-coreos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
-TEST_OS = continuous-atomic
+TEST_OS = fedora-coreos
 endif
 export TEST_OS
 TARFILE=$(PACKAGE_NAME)-$(VERSION).tar.gz


### PR DESCRIPTION
The continuous-atomic image got dropped a month ago [1] due to being
obsolete.

[1] https://github.com/cockpit-project/bots/pull/1178