### PR TITLE
actions: npm-update adjustments

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -1,8 +1,7 @@
 name: npm-update
 on:
-  # weekly automatic update on early Tuesday morning (before release day)
   schedule:
-    - cron: '50 2 * * 2'
+    - cron: '0 2 * * *'
   # can be run manually on https://github.com/cockpit-project/cockpit-ostree/actions
   workflow_dispatch:
 jobs:
@@ -23,4 +22,4 @@ jobs:
       - name: Run npm-update bot
         run: |
           make bots
-          bots/npm-update --verbose
+          bots/npm-update


### PR DESCRIPTION
 - Run the job daily, just like cockpituous does (roughly, it was much
   more probabilistic). Each run will only create one PR at most, so
   with weekly we would miss or drag out important updates.

 - Drop verbosity. It was useful for rolling this out, but it's prone to
   expose secrets, and not very interesting as a run is rather simple to
   reproduce locally.