### PR TITLE
workflows: Fix apt installation in npm-update

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
-        run: sudo apt-get install -y npm make
+        run: |
+          sudo apt update
+          sudo apt install -y npm make
 
       - name: Set up configuration and secrets
         run: |


### PR DESCRIPTION
GitHub's base VMs don't automatically refresh package indexes, so it can
happen that one of the package dependencies get out of date and are not
available on the mirrors any more.

Run `apt update` first to ensure that the workflow installs the latest
packages.

Ported from starter-kit commit 8771907002e2

-----

Fixes [last night's failure](https://github.com/cockpit-project/cockpit-ostree/runs/1534717420?check_suite_focus=true)