### PR TITLE
test: Use bitnami nginx container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git b7fc7bd5e517659c45531dcf84505902a17ec9e8
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 234
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -81,7 +81,7 @@ def ensure_remote_http_port (m, remote="local"):
 
 def start_trivial_httpd(m, remote="local", location=REPO_LOCATION):
     port = ensure_remote_http_port (m, remote)
-    pid = m.spawn("podman run -v {0}:/usr/share/nginx/html:ro,z -p {1}:80 nginx".format(location, port), "httpd")
+    pid = m.spawn("podman run -v {0}:/app:ro,z -p {1}:8080 nginx".format(location, port), "httpd")
 
     m.execute(["ostree", "summary", "--repo={}".format(location), "-u"])
     m.wait_for_cockpit_running(port=port)

--- a/test/vm.install
+++ b/test/vm.install
@@ -22,7 +22,7 @@ if [ ! -d /var/local-tree ]; then
 fi
 
 # originally docker.io/nginx, but that quickly runs into rate limits; use quay.io mirror
-podman pull quay.io/app-sre/nginx
+podman pull quay.io/bitnami/nginx
 
 # create a local repository for tests
 mkdir -p /var/local-repo


### PR DESCRIPTION
quay.io/app-sre/nginx became inaccessible.
https://quay.io/repository/bitnami/nginx is public and well maintained,
so use that instead.

----

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-1466-20201215-021903-c5c4036a-fedora-coreos-cockpit-project-cockpit-ostree/log.html)