### PR TITLE
workflows: Move npm-update to Ubuntu 20.04

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
         run: |


### PR DESCRIPTION
GitHub's 18.04 additional repositories break NPM. As "ubuntu-latest" is
going to switch to 20.04 soon anyway [1], do the jump now.

[1] https://github.com/actions/virtual-environments/issues/1816

Cherry-picked from starter-kit commit 33a665925bbfa.