### PR TITLE
Makefile: Output a path to the generated archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ devel-install: $(WEBPACK_TEST)
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
 dist-gzip: $(TARFILE)
+	echo `pwd`/$(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
 # we don't ship node_modules for license and compactness reasons; we ship a
@@ -113,7 +114,7 @@ $(TARFILE): $(WEBPACK_TEST) $(PACKAGE_NAME).spec
 	mv node_modules node_modules.release
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
-	tar czf $(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,$(PACKAGE_NAME)/,' \
+	tar czf $(TARFILE) --transform 's,^,$(PACKAGE_NAME)/,' \
 		--exclude $(PACKAGE_NAME).spec.in \
 		$$(git ls-files) lib/patternfly/*.scss package-lock.json $(PACKAGE_NAME).spec dist/
 	mv node_modules.release node_modules

--- a/packit.yaml
+++ b/packit.yaml
@@ -1,7 +1,7 @@
 specfile_path: cockpit-ostree.spec
 synced_files:
   - cockpit-ostree.spec
-upstream_project_name: cockpit-ostree
+upstream_package_name: cockpit-ostree
 downstream_package_name: cockpit-ostree
 actions:
   post-upstream-clone: make cockpit-ostree.spec


### PR DESCRIPTION
This is needed for packit to work.
Also reusing `$(TARFILE)` macro.