### PR TITLE
tools: Rename Fedora rawhide branch in cockpituous control file

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -19,7 +19,7 @@ job release-source
 job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
-job release-koji -k master
+job release-koji rawhide
 job release-koji f32
 job release-koji f33
 job release-bodhi F32


### PR DESCRIPTION
Fedora "master" branches were renamed recently.

Also make rawhide build failures fatal; the package build is so simple
that it really should not fail.