### PR TITLE
cockpituous: Add Fedora 34, drop Fedora 32

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -20,10 +20,10 @@ job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f32
 job release-koji f33
-job release-bodhi F32
+job release-koji f34
 job release-bodhi F33
+job release-bodhi F34
 
 job release-github
 job release-copr @cockpit/cockpit-preview


### PR DESCRIPTION
bodhi activation for Fedora 34 is today [1]. Drop Fedora 32 instead,
which is soon EOL.

[1] https://fedorapeople.org/groups/schedule/f-34/f-34-key-tasks.html