### PR TITLE
packit: Fix archive creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ devel-install: $(WEBPACK_TEST)
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
 dist-gzip: $(TARFILE)
-	echo `pwd`/$(TARFILE)
+	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
 # we don't ship node_modules for license and compactness reasons; we ship a

--- a/packit.yaml
+++ b/packit.yaml
@@ -1,8 +1,9 @@
 specfile_path: cockpit-ostree.spec
-synced_files:
-  - cockpit-ostree.spec
 upstream_package_name: cockpit-ostree
 downstream_package_name: cockpit-ostree
 actions:
   post-upstream-clone: make cockpit-ostree.spec
-  create-archive: make dist-gzip
+  # reduce memory consumption of webpack in sandcastle container
+  # https://github.com/packit/sandcastle/pull/92
+  # https://medium.com/the-node-js-collection/node-js-memory-management-in-container-environments-7eb8409a74e8
+  create-archive: make NODE_OPTIONS=--max-old-space-size=500 dist-gzip


### PR DESCRIPTION
Apply the same memory consumption reduction and tarfile printing fixes
as cockpit-podman recently did.

Also clean up `synced_files`, this should not be necessary any more with
current packit.