### PR TITLE
spec file: add Epoch 1

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -1,4 +1,5 @@
 Name: cockpit-ostree
+Epoch: 1
 Version: %{VERSION}
 Release: 1%{?dist}
 BuildArch: noarch


### PR DESCRIPTION
We accidentally released cockpit-ostree version 999 into Fedora while
testing the release process and some people have been stuck on that
version ever since.

Add an Epoch so that updates can continue as normal.