### PR TITLE
Port from moment to date-fns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,14 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 240; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 248; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 247; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 248; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ test/common:
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 248; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 80c9e57cdafaf0d6e4be6f907b6951a9854dcd7a; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@patternfly/patternfly": "4.115.2",
     "@patternfly/react-core": "4.135.0",
     "@patternfly/react-styles": "4.11.0",
-    "moment": "2.29.1",
+    "date-fns": "2.22.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "throttle-debounce": "2.3.0"

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -37,10 +37,11 @@ import {
     Nav, NavList, NavItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, OutlinedCheckCircleIcon } from '@patternfly/react-icons';
-import moment from 'moment';
 import { debounce } from 'throttle-debounce';
 
 import cockpit from 'cockpit';
+
+import * as timeformat from 'timeformat';
 
 import client from './client';
 import * as remotes from './remotes';
@@ -329,7 +330,7 @@ const DeploymentVersion = ({ info, packages }) => {
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Released") }</DescriptionListTerm>
-                <DescriptionListDescription className="timestamp" id="osrelease">{moment.unix(info.timestamp.v).fromNow()}</DescriptionListDescription>
+                <DescriptionListDescription className="timestamp" id="osrelease">{timeformat.distanceToNow(info.timestamp.v * 1000, true)}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Origin") }</DescriptionListTerm>

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -635,7 +635,6 @@ class OstreeCase(MachineCase):
         b.wait_in_text(".pf-c-empty-state__body", "Not authorized")
         self.assertIn("Reconnect", b.text(".pf-c-empty-state button"))
         self.allow_journal_messages("cannot reauthorize identity.*")
-        self.allow_failed_sudo_journal_messages()
 
     def testPageStatus(self):
         m = self.machine


### PR DESCRIPTION
moment is deprecated now. Use cockpit's new timeformat library instead,
which wraps date-fns and deals with localization automatically.

This fixes non-localized date/time formatting, as the page forgot to
call moment.locale().

----

There is no visual difference in English:

![main](https://user-images.githubusercontent.com/200109/125731651-74a57df8-6c78-428c-9470-6d82ddf52495.png)

It just looks different in other languages now due to the previously missing localization.