### PR TITLE
test/vm.install: allow new fedora: remote type

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -27,7 +27,7 @@ podman pull quay.io/bitnami/nginx
 # create a local repository for tests
 mkdir -p /var/local-repo
 ostree init --repo /var/local-repo --mode archive-z2
-branch=$(rpm-ostree status | sed -n '/ostree:/ { s/^.*://; p; q }')
+branch=$(rpm-ostree status | sed -n '/\(fedora\|ostree\):/ { s/^.*://; p; q }')
 ostree commit -s "cockpit-tree" --repo /var/local-repo --add-metadata-string version=cockpit-base.1  --tree=dir=/var/local-tree  -b $branch
 ostree remote add local file:///var/local-repo --no-gpg-verify
 # on fedora-coreos we use `rpm-ostree install`, which collides on rebase


### PR DESCRIPTION
When trying to fetch the branch name out of the booted image, allow for
the new fedora: remote type, in addition to ostree:.