### PR TITLE
webpack: Use default resolve path for npm 7 compatibility

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,6 @@ const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
 const webpack = require("webpack");
 
-const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");
-
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
 
@@ -56,10 +54,11 @@ const babel_loader = {
 module.exports = {
     mode: production ? 'production' : 'development',
     resolve: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
+        alias: { 'font-awesome': 'font-awesome-sass/assets/stylesheets' },
     },
     resolveLoader: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
     },
     watchOptions: {
         ignored: /node_modules/,


### PR DESCRIPTION
npm 7 changed how it resolves dependencies, and projects fail to build
with lots of unresolved peer dependencies of PatternFly.

With an absolute path, `resolve.modules` will only look in that
directory; the default is a relative path "node_modules" that just
works [1]. Use that default, as we don't use `$SRCDIR` in this project
anyway.

[1] https://webpack.js.org/configuration/resolve/#resolvemodules

Cherry-picked from starter-kit commit 0abeda35284b84e497.