### PR TITLE
Prevent [Object object] from being shown

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -465,6 +465,9 @@ class Application extends React.Component {
         };
 
         const show_failure = ex => {
+            if (Array.isArray(ex) && ex.length >= 1) {
+              ex = ex[0];
+            }
             let message = null;
             let final = false;
 


### PR DESCRIPTION
When switching from administrative to limited the exception is an array
which prints [Object object] as console.message prints an array.