### PR TITLE
Bring back translation updates

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# (Re-)generate all deploy keys on https://github.com/cockpit-project/cockpit-ostree/settings/environments
+
+set -eux
+
+ORG=cockpit-project
+THIS=cockpit-ostree
+
+[ -e bots ] || make bots
+
+# for weblate-sync-pot.yml: push to https://github.com/cockpit-project/cockpit-ostree-weblate/settings/keys
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env "${THIS}-weblate" --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}-weblate"

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -1,0 +1,45 @@
+name: weblate-sync-po
+on:
+  schedule:
+    # Run this on Tuesday evening (UTC), so that it's ready for release on
+    # Wednesday, with some spare time
+    - cron: '0 18 * * 2'
+  # can be run manually on https://github.com/cockpit-project/cockpit-ostree/actions
+  workflow_dispatch:
+
+jobs:
+  po-refresh:
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends gettext
+
+      - name: Clone source repository
+        uses: actions/checkout@v2
+        with:
+          path: src
+
+      - name: Clone weblate repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}-weblate
+          path: weblate
+
+      - name: Copy .po files from weblate repository
+        run: cp weblate/*.po src/po/
+
+      - name: Run po-refresh bot
+        run: |
+          cd src
+          make bots
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          mkdir -p ~/.config/cockpit-dev
+          echo ${{ github.token }} >> ~/.config/cockpit-dev/github-token
+          PO_REFRESH_NO_SYNC=1 bots/po-refresh

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -1,0 +1,42 @@
+name: weblate-sync-pot
+on:
+  schedule:
+    # Run this every morning
+    - cron: '45 2 * * *'
+  # can be run manually on https://github.com/cockpit-project/cockpit-ostree/actions
+  workflow_dispatch:
+
+jobs:
+  pot-upload:
+    environment: cockpit-ostree-weblate
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends npm make gettext
+
+      - name: Clone source repository
+        uses: actions/checkout@v2
+        with:
+          path: src
+
+      - name: Generate .pot file
+        run: make -C src po/cockpit-ostree.pot
+
+      - name: Clone weblate repository
+        uses: actions/checkout@v2
+        with:
+          path: weblate
+          repository: ${{ github.repository }}-weblate
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Commit .pot to weblate repo
+        run: |
+          cp src/po/cockpit-ostree.pot weblate/
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          git -C weblate commit -m "Update source file" -- cockpit-ostree.pot
+          git -C weblate push

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,6 @@ all: $(WEBPACK_TEST)
 # i18n
 #
 
-LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
-WEBLATE_REPO=tmp/weblate-repo
-WEBLATE_REPO_URL=https://github.com/cockpit-project/cockpit-ostree-weblate.git
-WEBLATE_REPO_BRANCH=main
-
 po/$(PACKAGE_NAME).js.pot:
 	xgettext --default-domain=cockpit --output=$@ --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
@@ -44,26 +39,6 @@ po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 
 po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot
 	msgcat --sort-output --output-file=$@ $^
-
-# Update translations against current PO template
-update-po: po/$(PACKAGE_NAME).pot
-	for lang in $(LINGUAS); do \
-		msgmerge --output-file=po/$$lang.po po/$$lang.po $<; \
-	done
-
-$(WEBLATE_REPO):
-	git clone --depth=1 -b $(WEBLATE_REPO_BRANCH) $(WEBLATE_REPO_URL) $(WEBLATE_REPO)
-
-upload-pot: po/$(PACKAGE_NAME).pot $(WEBLATE_REPO)
-	cp ./po/$(PACKAGE_NAME).pot $(WEBLATE_REPO)
-	git -C $(WEBLATE_REPO) commit -m "Update source file" -- $(PACKAGE_NAME).pot
-	git -C $(WEBLATE_REPO) push
-
-clean-po:
-	rm ./po/*.po
-
-download-po: $(WEBLATE_REPO)
-	cp $(WEBLATE_REPO)/*.po ./po/
 
 #
 # Build/Install/dist
@@ -183,4 +158,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check check-unit vm update-po
+.PHONY: all clean install devel-install dist-gzip srpm rpm check check-unit vm

--- a/po/html2po
+++ b/po/html2po
@@ -45,9 +45,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -26,9 +26,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {
@@ -70,11 +70,19 @@ function step() {
     if (path.basename(filename) != "manifest.json")
         return step();
 
-    fs.readFile(filename, { encoding: "utf-8"}, function(err, data) {
+    /* Qualify the filename if necessary */
+    var full = filename;
+    if (opts.directory)
+        full = path.join(opts.directory, filename);
+
+    fs.readFile(full, { encoding: "utf-8"}, function(err, data) {
         if (err)
             fatal(err.message);
 
-        process_manifest(JSON.parse(data));
+        // There are variables which when not substituted can cause JSON.parse to fail
+        // Dummy replace them. None variable is going to be translated anyway
+        safe_data = data.replace(/\@.+?\@/gi, 1);
+        process_manifest(JSON.parse(safe_data));
 
         return step();
     });
@@ -92,7 +100,7 @@ function process_keywords(keywords) {
         v.matches.forEach(keyword =>
             push({
                 msgid: keyword,
-                locations: [ filename ]
+                locations: [ filename + ":0" ]
             })
         );
     });
@@ -102,7 +110,7 @@ function process_docs(docs) {
     docs.forEach(doc => {
         push({
             msgid: doc.label,
-            locations: [ filename ]
+            locations: [ filename + ":0" ]
         })
     });
 }
@@ -112,7 +120,7 @@ function process_menu(menu) {
         if (menu[m].label) {
             push({
                 msgid: menu[m].label,
-                locations: [ filename ]
+                locations: [ filename + ":0" ]
             });
         }
         if (menu[m].keywords)

--- a/test/run
+++ b/test/run
@@ -6,3 +6,5 @@ set -eu
 
 [ -z "${TEST_SCENARIO:-}" ] || export TEST_BROWSER="$TEST_SCENARIO"
 make check
+
+make po/cockpit-ostree.pot


### PR DESCRIPTION
This is a bit fiddly to test right now, as the new workflows are not on main yet. I did [create the github env](https://github.com/cockpit-project/cockpit-ostree/settings/environments), and the [weblate repo](https://github.com/cockpit-project/cockpit-ostree-weblate) otherwise looks as expected. In the interest of not jumping through too many hoops, could we merge this, then run the workflows manually, and I sort out possible fallout afterwards? (Then in subsequent PRs, we can easily run the workflows from the fork)