### PR TITLE
test: Bump test/common API to get along with Cockpit 258 shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 257; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git c3309b7a56099ec750ebb7ee72c9b1a9944de0b8; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ test/common:
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 257; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 258; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/commit/c3309b7a560

----

Fixes [this test failure](https://logs.cockpit-project.org/logs/pull-218-20211201-023211-99ab0751-fedora-coreos/log.html) from PR #218 or [the image refresh](https://github.com/cockpit-project/bots/pull/2678)

I visually tested the pkg/lib bump, looks fine.