### PR TITLE
Fix typos and spelling errors found by codespell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git c3309b7a56099ec750ebb7ee72c9b1a9944de0b8; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 259; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -69,14 +69,14 @@ function track_id(item) {
 }
 
 function format_version(deployment) {
-    var formated = "";
+    var formatted = "";
     if (!deployment || !deployment.osname)
         return;
 
     if (deployment.version)
-        formated = deployment.version.v;
+        formatted = deployment.version.v;
 
-    return cockpit.format("$0 $1", deployment.osname.v, formated);
+    return cockpit.format("$0 $1", deployment.osname.v, formatted);
 }
 
 // https://github.com/cockpit-project/cockpit/blob/main/pkg/lib/notifications.js

--- a/src/client.js
+++ b/src/client.js
@@ -13,7 +13,7 @@ const TRANSACTION = 'org.projectatomic.rpmostree1.Transaction';
 /*
  * Breaks down progress messages into
  * a string that can be displayed
- * Similar to the cli output but simplier.
+ * Similar to the cli output but simpler.
  * We don't display object counts or bytes/s.
  * Percentages are only possible when
  * we actually know what is going to be pulled.
@@ -28,7 +28,7 @@ const TRANSACTION = 'org.projectatomic.rpmostree1.Transaction';
  * delta data (uuut): (total parts, fetched parts,
  *                     total super blocks, total size)
  * content objects (uu): (fetched objects, requested objects)
- * transfer data (tt): (bytes transfered, bytes/s)
+ * transfer data (tt): (bytes transferred, bytes/s)
  */
 
 function build_progress_line(progress_arg) {
@@ -442,7 +442,7 @@ class RPMOSTreeDBusClient {
     }
 
     /* This is a little fragile because the
-     * the dbus varient is simply 'av'.
+     * the dbus variant is simply 'av'.
      * Ostree promises to not remove or change the
      * order of any of these attributes.
      *  https://github.com/ostreedev/ostree/commit/4a2733f9e7e2ca127ff27433c045c977000ca346#diff-c38f32cb7112030f3326b43e305f2accR424

--- a/src/ostree.scss
+++ b/src/ostree.scss
@@ -26,7 +26,7 @@
 }
 
 .available-deployments {
-    // Remove data-list border - items are seperated by margin
+    // Remove data-list border - items are separated by margin
     border: none;
     // Set up max width for the data list
     max-width: 60rem;
@@ -63,7 +63,7 @@
     width: 100%;
 }
 
-// Add a border line bellow the navigatin
+// Add a border line below the navigatin
 .available-deployments .pf-c-nav {
     background: linear-gradient(0deg,var(--pf-global--BorderColor--100) 0,var(--pf-global--BorderColor--100) 1px,transparent 0);
 


### PR DESCRIPTION
This is all in comments, including some imported files, except for one function where the variable is changed throughout. I'll comment on that to highlight it below.