### PR TITLE
Move page status icons to PF4

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -91,7 +91,7 @@ const set_update_status = debounce(1000, versions => {
         if (versions[0].booted && versions[0].booted.v) {
             set_page_status({
                 title: _("System is up to date"),
-                details: { icon: "fa fa-check-circle-o" }
+                details: { pficon: "check" }
             });
         } else {
             /* report the available update */
@@ -500,7 +500,7 @@ class Application extends React.Component {
                     title: _("Checking for package updates..."),
                     details: {
                         link: false,
-                        icon: "spinner spinner-xs",
+                        pficon: "spinner",
                     },
                 });
             })

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -636,8 +636,7 @@ class OstreeCase(MachineCase):
         m.start_cockpit()
         b.login_and_go("/system")
         b.wait_text("#page_status_notification_updates", "System is up to date")
-        self.assertEqual(b.attr("#page_status_notification_updates span:first-child", "class"),
-                         "fa fa-check-circle-o")
+        self.assertEqual(b.attr("#page_status_notification_updates svg", "data-pficon"), "check")
         # go to updates page
         b.click("#page_status_notification_updates a")
         b.enter_page("/updates")


### PR DESCRIPTION
Move away from the PF3 FontAwesome names in favor of the PF4 icon components.

See https://github.com/cockpit-project/cockpit/commit/85fd223bfc261826cb4c607efb6ef38f11609b47

Fixes #226