### PR TITLE
cockpituous: Add Fedora 36, drop 34

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -20,10 +20,10 @@ job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f34
 job release-koji f35
-job release-bodhi F34
+job release-koji f36
 job release-bodhi F35
+# job release-bodhi F36  # enable after 2022-02-22
 
 job release-github
 job release-copr @cockpit/cockpit-preview


### PR DESCRIPTION
Fedora 36 got branched off and now needs its own koji builds. It does
not yet use bodhi. See
https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html

Drop Fedora 34, so that we keep the two latest releases, as usual.