### PR TITLE
test: Bump Cockpit test API to 267, use --track-naughties option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ check-unit: $(NODE_MODULES_TEST)
 # run the browser integration tests; skip check for SELinux denials
 # this will run all tests/check-* and format them as TAP
 check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common check-unit
-	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests
+	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests ${RUN_TESTS_OPTIONS}
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from main, as only that has current and existing images; but testvm.py API is stable
@@ -143,7 +143,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 261; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/run
+++ b/test/run
@@ -5,6 +5,7 @@ set -eu
 # arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
 
 [ -z "${TEST_SCENARIO:-}" ] || export TEST_BROWSER="$TEST_SCENARIO"
+export RUN_TESTS_OPTIONS=--track-naughties
 make check
 
 make po/cockpit-ostree.pot


### PR DESCRIPTION
run-tests recently got a new `--track-naughties` option [1] to explicitly
enable updating known issues on GitHub. Enable it for CI runs, and leave
it disabled for local runs and PackIt, as in these cases we don't want
to try and talk to GitHub.

[1] https://github.com/cockpit-project/cockpit/commit/7ef88e80ce613c

Cherry-picked from starter-kit commit a937b82cd2dc.