### PR TITLE
test: switch to new container image

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -66,7 +66,7 @@ def ensure_remote_http_port (m, remote="local"):
 
 def start_trivial_httpd(m, remote="local", location=REPO_LOCATION):
     port = ensure_remote_http_port (m, remote)
-    pid = m.spawn(f"podman run -v {location}:/app:ro,z -p {port}:8080 nginx", "httpd")
+    pid = m.spawn(f"podman run -v {location}:/usr/local/nginx/html:ro,z -p {port}:80 quay.io/jitesoft/nginx", "httpd")
 
     m.execute(["ostree", "summary", f"--repo={location}", "-u"])
     m.wait_for_cockpit_running(port=port)

--- a/test/vm.install
+++ b/test/vm.install
@@ -22,7 +22,7 @@ if [ ! -d /var/local-tree ]; then
 fi
 
 # originally docker.io/nginx, but that quickly runs into rate limits; use quay.io mirror
-podman pull quay.io/bitnami/nginx
+podman pull quay.io/jitesoft/nginx
 
 # create a local repository for tests
 mkdir -p /var/local-repo


### PR DESCRIPTION
The bitnami image mirrored from dockerhub was removed from quay.io and
as we can't pull from dockerhub due to rate limitting use a different
nginx image. In the future the image should be pulled into the testing
container so tests can run fully offline.

Note, I've attempted to use the smaller lighttpd image but this image does not work well with our tests, the container isn't getting killed with `stop_trivial_httpd`. No Python image seems to be available on quay.io for us to simply use python -m http.server 