### PR TITLE
test: offline image-customize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,11 @@ $(RPMFILE): $(SRPMFILE) bots
 $(VM_IMAGE): rpm bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v --upload $$(ls $(PACKAGE_NAME)-*.noarch.rpm):/tmp/ \
-		--run-command 'rpm -q cockpit-ostree && rpm-ostree override replace /tmp/*.rpm || rpm-ostree install /tmp/*.rpm' \
+		--no-network \
+		--run-command 'rpm -q cockpit-ostree && rpm-ostree --cache-only override replace /tmp/*.rpm || rpm-ostree --cache-only install /tmp/*.rpm' \
 		$(TEST_OS)
 	# building the local tree needs the modified tree from above booted already
-	bots/image-customize -v --script $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize -v --no-network --script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/test/vm.install
+++ b/test/vm.install
@@ -21,9 +21,6 @@ if [ ! -d /var/local-tree ]; then
     ostree checkout "$checkout" /var/local-tree
 fi
 
-# originally docker.io/nginx, but that quickly runs into rate limits; use quay.io mirror
-podman pull quay.io/jitesoft/nginx
-
 # create a local repository for tests
 mkdir -p /var/local-repo
 ostree init --repo /var/local-repo --mode archive-z2


### PR DESCRIPTION
Create the test virtual machine offline now that the coreos image
contains the used nignx container. For rpm-ostree to run offline, invoke
it with --cache-only so it doesn't try to fetch repository data.