### PR TITLE
packit: Fix copr owner

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -20,8 +20,8 @@ jobs:
   - job: copr_build
     trigger: release
     metadata:
-      owner: cockpit
-      project: cockpit-preview
+      owner: "@cockpit"
+      project: "cockpit-preview"
       preserve_project: True
       targets:
       - fedora-35


### PR DESCRIPTION
"cockpit" is a group, not an user, so add the missing `@` prefix.

See https://github.com/cockpit-project/cockpit-ostree/commit/043dbbeeee56fd792d8b4be62bfa948990c9b8e9#commitcomment-73382041