### PR TITLE
packit: Drop Fedora 35, add Fedora 37

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -27,9 +27,8 @@ jobs:
       project: "cockpit-preview"
       preserve_project: True
       targets:
-      - fedora-35
       - fedora-36
-      - fedora-development
+      - fedora-37
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
     actions:
@@ -45,21 +44,21 @@ jobs:
     metadata:
       dist_git_branches:
         - fedora-development
-        - fedora-35
         - fedora-36
+        - fedora-37
 
   - job: koji_build
     trigger: commit
     metadata:
       dist_git_branches:
         - fedora-development
-        - fedora-35
         - fedora-36
+        - fedora-37
 
   - job: bodhi_update
     trigger: commit
     metadata:
       dist_git_branches:
         # rawhide updates are created automatically
-        - fedora-35
         - fedora-36
+        - fedora-37


### PR DESCRIPTION
As usual, keep supporting the two most recent branched versions.

Also drop Rawhide from our cockpit-preview COPR build: We directly
upload new releases to Rawhide anyway, so this is redundant.