### PR TITLE
Install into /usr/local/share/ by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TARFILE=$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q $(PACKAGE_NAME).spec.in).rpm
 SRPMFILE=$(subst noarch,src,$(RPMFILE))
+PREFIX ?= /usr/local
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json
@@ -59,8 +60,8 @@ clean:
 	[ ! -e $(PACKAGE_NAME).spec.in ] || rm -f $(PACKAGE_NAME).spec
 
 install: $(WEBPACK_TEST)
-	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
-	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
+	mkdir -p $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
+	cp -r dist/* $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
 
 # this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(WEBPACK_TEST)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make
 
 # Installing
 
-`make install` compiles and installs the package in `/usr/share/cockpit/`. The
+`make install` compiles and installs the package in `/usr/local/share/cockpit/`. The
 convenience targets `srpm` and `rpm` build the source and binary rpms,
 respectively. Both of these make use of the `dist` target, which is used
 to generate the distribution tarball. In `production` mode, source files are

--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -21,7 +21,7 @@ Cockpit component for managing software updates for ostree based systems.
 %setup -n cockpit-ostree
 
 %install
-%make_install
+%make_install PREFIX=/usr
 
 %files
 %doc README.md


### PR DESCRIPTION
/usr is package manager territory, and not even writable on OSTree based systems such as Fedora CoreOS or RHEL Edge. Given that we primarily target OSTree, `make install` should do the right thing there.

You can still override this with `make install PREFIX=...`. Use that in the RPM spec file.


---

Motivated by https://bugzilla.redhat.com/show_bug.cgi?id=2126471