### PR TITLE
packit: Drop targets list from COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -28,11 +28,6 @@ jobs:
       owner: "@cockpit"
       project: "cockpit-preview"
       preserve_project: True
-      targets:
-      - fedora-36
-      - fedora-37
-      - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
     actions:
       post-upstream-clone: make cockpit-ostree.spec
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this

--- a/packit.yaml
+++ b/packit.yaml
@@ -1,4 +1,6 @@
 upstream_project_url: https://github.com/cockpit-project/cockpit-ostree
+# enable notification of failed downstream jobs as issues
+issue_repository: https://github.com/cockpit-project/cockpit-ostree
 specfile_path: cockpit-ostree.spec
 upstream_package_name: cockpit-ostree
 downstream_package_name: cockpit-ostree


### PR DESCRIPTION
Hardcoding this list is redundant and hard to change: changing the COPR
config and updating all our projects' packit.yml files needs to happen
in lockstep.

packit now learned to just read the configuration from an existing COPR
repository, so drop the target list entirely. See 
https://github.com/packit/packit-service/issues/1499

----

I successfully tested this on my fork, see [this conversation ff.](https://github.com/packit/packit-service/issues/1499#issuecomment-1260449494) -- it needed two rounds, yesterday there was still an error on the packit side.