### PR TITLE
.github: update checkout action to v3

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -19,7 +19,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -19,7 +19,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -21,12 +21,12 @@ jobs:
           sudo apt install -y --no-install-recommends gettext
 
       - name: Clone source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
 
       - name: Clone weblate repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}-weblate
           path: weblate

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt install -y --no-install-recommends npm make gettext
 
       - name: Clone source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
 
@@ -27,7 +27,7 @@ jobs:
         run: make -C src po/cockpit-ostree.pot
 
       - name: Clone weblate repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: weblate
           repository: ${{ github.repository }}-weblate


### PR DESCRIPTION
actions/checkout@v3 uses nodejs 16 as runtime instead of the deprecated nodejs 12 runtime.