### PR TITLE
Fix for Fedora 37 task container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,16 +98,9 @@ $(SRPMFILE): $(TARFILE) $(PACKAGE_NAME).spec
 
 rpm: $(RPMFILE)
 
-# this is a noarch build, so local rpm build works fine for recent OSes; but
-# RHEL/CentOS Atomic don't get along with rpms built on Fedora ≥ 31
+# this is a noarch build, so local rpm build works fine for recent OSes
 $(RPMFILE): $(SRPMFILE) bots
-	set -e; srpm=`ls *.src.rpm | head -n1`; \
-	if [ "$${TEST_OS%-atomic}" != "$$TEST_OS" ]; then \
-	    bots/image-download centos-7; \
-	    test/rpmbuild-vm "$$srpm" centos-7; \
-	else \
-	    test/rpmbuild-local "$$srpm"; \
-	fi
+	test/rpmbuild-local $(SRPMFILE)
 
 # build a VM with locally built rpm installed, cockpit/ws container, and local
 # ostree for testing

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 278; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ endif
 export TEST_OS
 TARFILE=$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(PACKAGE_NAME)-node-$(VERSION).tar.xz
-RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q $(PACKAGE_NAME).spec.in).rpm
-SRPMFILE=$(subst noarch,src,$(RPMFILE))
+# rpmspec -q behaves differently in Fedora ≥ 37
+RPMQUERY=$(shell rpmspec -D"VERSION $(VERSION)" -q --srpm $(PACKAGE_NAME).spec.in).rpm
+SRPMFILE=$(subst noarch,src,$(RPMQUERY))
+RPMFILE=$(subst src,noarch,$(RPMQUERY))
 PREFIX ?= /usr/local
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 # Automated Testing
 
 Run `make check` to build an RPM, install it into a standard Cockpit test VM
-(fedora-atomic by default), and run the test/check-ostree integration test on
+(fedora-coreos by default), and run the test/check-ostree integration test on
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
@@ -76,11 +76,7 @@ After the test VM is prepared, you can manually run the test without rebuilding
 the VM, possibly with extra options for tracing and halting on test failures
 (for interactive debugging):
 
-    TEST_OS=fedora-atomic test/check-ostree -tvs
-
-You can also run the test against a different Cockpit image, for example:
-
-    TEST_OS=continuous-atomic make check
+    TEST_OS=fedora-coreos test/check-ostree -tvs
 
 # Automated release
 

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -152,10 +152,7 @@ class OstreeRestartCase(MachineCase):
         # Delete local remote so we start clean, without a file based remote
         ensure_remote_http_port(m)
 
-        if m.image in ["fedora-coreos"]:
-            remove_pkg = m.execute("rpm -qa | grep socat").strip()
-        else:
-            remove_pkg = m.execute("rpm -qa | grep cockpit-docker").strip()
+        remove_pkg = m.execute("rpm -qa | grep socat").strip()
 
         rhsmcertd_hack(m)
 
@@ -377,9 +374,6 @@ class OstreeRestartCase(MachineCase):
         b.wait_not_present(f"{get_list_item(1)} div.packages")
         b.click(f'{get_list_item(1)} ul li a:contains("Packages")')
         b.wait_visible(f"{get_list_item(1)} div.packages")
-        # Atomics have cockpit-ostree preinstalled, FCOS doesn't
-        if m.image not in ["fedora-coreos"]:
-            b.wait_in_text(f"{get_list_item(1)} div.packages", "cockpit-ostree")
 
         # wait until the button has stabilized
         for retry in range(3):

--- a/test/vm.install
+++ b/test/vm.install
@@ -7,13 +7,7 @@ mkdir -p /etc/cockpit
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 
 # Install cockpit and run it once to generate certificate; avoids slow startups during tests
-# different commands on Atomic and Fedora CoreOS
-if type atomic >/dev/null 2>&1; then
-    atomic install cockpit/ws
-    atomic --ignore run cockpit/ws
-else
-    podman container runlabel INSTALL cockpit/ws
-fi
+podman container runlabel INSTALL cockpit/ws
 
 # fedora-coreos does not have this checkout
 if [ ! -d /var/local-tree ]; then


### PR DESCRIPTION
Fedora 37's rpmspec changed behaviour: `-q` now shows the source RPM
name instead of the binary one. `--srpm` and `--rpms` don't influence
this behaviour any more. So get along with both variants.

---

See #289 for the current test failure.