### PR TITLE
cockpit-ostree.spec.in: Migrate spec to SPDX license

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -4,7 +4,7 @@ Version: %{VERSION}
 Release: 1%{?dist}
 BuildArch: noarch
 Summary: Cockpit user interface for rpm-ostree
-License: LGPLv2+
+License: LGPL-2.1-or-later
 BuildRequires: make
 Requires: cockpit-bridge >= 125
 Requires: cockpit-system >= 125


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

Also see 9bb49fe1c4d027a37eab61e8a2b187ffef168a2d in cockpit.