### PR TITLE
Fix rhel-edge name and fill background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,10 @@ bots:
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
+# 811a679947d785c969e71403cde8f94156eb8bde = 284 + #18263
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 282.1; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 811a679947d785c969e71403cde8f94156eb8bde; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div id="app" class="ct-page-fill"></div>
 </body>
 </html>

--- a/src/ostree.scss
+++ b/src/ostree.scss
@@ -19,6 +19,7 @@
 
 /* ---------------------------------------------------------------------------------------------------- */
 
+@use "page.scss";
 @import "./lib/patternfly/patternfly-4-overrides.scss";
 
 .available-deployments-nav-content {

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -121,7 +121,7 @@ def rhsmcertd_hack(m):
 
 def get_name(self):
     if self.image == "rhel4edge":
-        return "rhel"
+        return "rhel-edge"
     return "fedora-coreos"
 
 
@@ -632,7 +632,7 @@ class OstreeCase(MachineCase):
         b.wait_in_text(".pf-c-empty-state__body", "Not authorized")
         self.assertIn("Reconnect", b.text(".pf-c-empty-state button"))
 
-        b.become_superuser()
+        b.become_superuser(passwordless=m.image == "rhel4edge")
         b.switch_to_frame("cockpit1:localhost/updates")
         b.wait_visible('.available-deployments')
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -18,7 +18,7 @@ fi
 # create a local repository for tests
 mkdir -p /var/local-repo
 ostree init --repo /var/local-repo --mode archive-z2
-branch=$(rpm-ostree status | sed -n '/\(fedora\|ostree\|rhel\):/ { s/^.*://; p; q }')
+branch=$(rpm-ostree status | sed -n '/\(fedora\|ostree\|rhel-edge\):/ { s/^.*://; p; q }')
 ostree commit -s "cockpit-tree" --repo /var/local-repo --add-metadata-string version=cockpit-base.1  --tree=dir=/var/local-tree  -b $branch
 ostree remote add local file:///var/local-repo --no-gpg-verify
 # on fedora-coreos we use `rpm-ostree install`, which collides on rebase


### PR DESCRIPTION
When using offical kickstart the name differs a bit. Also piggybacking small UI fix