### PR TITLE
test with python bridge

### DIFF
--- a/cockpit-askpass
+++ b/cockpit-askpass
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+import sys
+from cockpit._vendor.ferny.interaction_client import main
+sys.exit(main())


### PR DESCRIPTION
Build the Python bridge from the cockpit project and install it into the VM so we can run tests against it.

The fedora-coreos image does not have pip, and rpm-ostree install makes it unwieldy to install on the fly as it has so many dependencies (which can't be updated if they are installed in an older version).

So instead of building and installing a wheel, copy our two modules into the site directory, and create a /usr/local/bin/cockpit-bridge wrapper. This is a giant hack, but only temporary until we package the pybridge into cockpit-bridge.rpm.

---

 - [x] https://github.com/cockpit-project/cockpit/pull/18296
 - [x] https://github.com/cockpit-project/cockpit/pull/18314
 - [x] Fix (https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3272) ; got into F37 and F38 now
 - [x] https://github.com/cockpit-project/bots/issues/4669 to pick it up in our fedora-coreos image
 - [ ] RHEL/CentOS 9 backport: https://bugzilla.redhat.com/show_bug.cgi?id=2217771

I know @allisonkarlitskaya is allergic to this, and I am allergic to installing pip (or any other build-time dependency) directly onto our image. I don't want to spend time with a temporary spec which builds cockpit-bridge.rpm with the pybridge in c-ostree's Makefile, so I propose to just keep this around as a draft and test c-ostree occasionally here.