### PR TITLE
manifest: Add condition

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,10 @@
     "requires": {
         "cockpit": "125"
     },
+    "conditions": [
+        {"path-exists": "/usr/bin/rpm-ostree"},
+        {"path-exists": "/sysroot/ostree"}
+    ],
 
     "tools": {
         "index": {


### PR DESCRIPTION
Only show ostree if the system is actually *using* OSTree, by checking for /sysroot/ostree. It sometimes happens that users install cockpit-ostree on classic RPM systems, which "breaks" the "Software Updates" page.

This is a better solution than the current static priorities of packagekit vs. ostree. However, this only works with the Python bridge [1].

Fixes #295

[1] https://github.com/cockpit-project/cockpit/pull/18291