### PR TITLE
build: Move to a webpack module, generalize bundler language/variable names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = bc5ea7cc137ffc2f4de23976ac3893896a837c0d # 285
+COCKPIT_REPO_COMMIT = 54f2fd58a3645c4a222e2b1b9b5f1b9321bed998 # 285 + Move to a webpack module
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
@@ -56,10 +56,10 @@ po/$(PACKAGE_NAME).js.pot:
 		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/html2po -o $@ $$(find src -name '*.html')
+	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/manifest2po src/manifest.json -o $@
+	pkg/lib/manifest2po.js src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot
 	msgcat --sort-output --output-file=$@ $^

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ your browser.
 
 You can also use
 [watch mode](https://webpack.js.org/guides/development/#using-watch-mode) to
-automatically update the webpack on every code change with
+automatically update the bundle on every code change with
 
     $ npm run watch
 
@@ -50,7 +50,7 @@ or
 Cockpit Starter Kit uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.js` and `.jsx` files.
 
-The linter is executed within every build as a webpack preloader.
+eslint is executed within every build.
 
 For developer convenience, the ESLint can be started explicitly by:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cockpit-ostree",
   "description": "Manage software updates for ostree based systems in Cockpit",
+  "type": "module",
   "main": "index.js",
   "repository": "git@github.com:cockpit-project/cockpit-ostree.git",
   "author": "",

--- a/src/remotes.js
+++ b/src/remotes.js
@@ -18,8 +18,8 @@
  */
 
 import cockpit from 'cockpit';
-import client from './client';
-import { parseData, changeData } from './utils';
+import client from './client.js';
+import { parseData, changeData } from './utils.js';
 
 const _ = cockpit.gettext;
 

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -17,15 +17,15 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-const QUnit = require("qunit");
-const utils = require("./utils");
+import QUnit from 'qunit';
+import * as utils from './utils.js';
 
 const sample_config = `
 key = value
 
 [section]
 key=section
- indented = commas, or spaces     
+ indented = commas, or spaces
 
 [ section2 ]
 key = section2

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,7 @@ function formatOptions(options) {
     return output.join("\n") + "\n\n";
 }
 
-function parseData(string) {
+export function parseData(string) {
     const data = {};
     const lines = string ? string.split(configRegex.lines) : [];
     let section = null;
@@ -62,7 +62,7 @@ function parseData(string) {
     return data;
 }
 
-function changeData(string, section, options) {
+export function changeData(string, section, options) {
     const lines = string ? string.split(configRegex.lines) : [];
     let in_section = false;
     const remaining = options;
@@ -110,5 +110,3 @@ function changeData(string, section, options) {
 
     return output;
 }
-
-module.exports = { parseData, changeData };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
 
-const copy = require("copy-webpack-plugin");
-const extract = require("mini-css-extract-plugin");
-const TerserJSPlugin = require('terser-webpack-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const CompressionPlugin = require("compression-webpack-plugin");
-const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
-const CockpitRsyncPlugin = require("./pkg/lib/cockpit-rsync-plugin");
-const ESLintPlugin = require('eslint-webpack-plugin');
+import copy from "copy-webpack-plugin";
+import extract from "mini-css-extract-plugin";
+import TerserJSPlugin from 'terser-webpack-plugin';
+import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+import CompressionPlugin from "compression-webpack-plugin";
+import ESLintPlugin from 'eslint-webpack-plugin';
+
+import CockpitPoPlugin from "./pkg/lib/cockpit-po-plugin.js";
+import CockpitRsyncPlugin from "./pkg/lib/cockpit-rsync-plugin.js";
 
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
@@ -27,9 +27,9 @@ const copy_files = [
 
 const plugins = [
     new copy({ patterns: copy_files }),
-    new extract({filename: "[name].css"}),
+    new extract({ filename: "[name].css" }),
     new CockpitPoPlugin(),
-    new CockpitRsyncPlugin({dest: packageJson.name}),
+    new CockpitRsyncPlugin({ dest: packageJson.name }),
 ];
 
 if (eslint) {
@@ -50,32 +50,32 @@ const babel_loader = {
     options: {
         presets: [
             ["@babel/env", {
-                "targets": {
-                    "chrome": "57",
-                    "firefox": "52",
-                    "safari": "10.3",
-                    "edge": "16",
-                    "opera": "44"
+                targets: {
+                    chrome: "57",
+                    firefox: "52",
+                    safari: "10.3",
+                    edge: "16",
+                    opera: "44"
                 }
             }],
             "@babel/preset-react"
         ]
     }
-}
+};
 
-module.exports = {
+const config = {
     mode: production ? 'production' : 'development',
     resolve: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
     },
     resolveLoader: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
     },
     watchOptions: {
         ignored: /node_modules/,
     },
     entry: {
-        ostree: [ "./src/app.jsx", "./src/ostree.scss" ],
+        ostree: ["./src/app.jsx", "./src/ostree.scss"],
     },
     devtool: "source-map",
     stats: "errors-warnings",
@@ -166,5 +166,7 @@ module.exports = {
             },
         ]
     },
-    plugins: plugins
-}
+    plugins
+};
+
+export default config;


### PR DESCRIPTION
Cockpit recently changed to an ESM build system [1]. Bump COCKPIT_REPO_COMMIT to that and follow suit.

Adjust some imports/exports to be ESM conformant.

[1] https://github.com/cockpit-project/cockpit/pull/18366

----

Pretty much identical to https://github.com/cockpit-project/starter-kit/pull/625 except for some extra import fixes.