### PR TITLE
Port most of src/client.js to standard Promises

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po
 $(DIST_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
 	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 
-watch:
+watch: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
 	NODE_ENV=$(NODE_ENV) npm run watch
 
 clean:


### PR DESCRIPTION
cockpit.defer() has been deprecated for a long time. Replace with    
standard Promise API and chaining.    
    
There is one instance left which uses the .notify() API. Replacing this    
needs some more work.    
