### PR TITLE
packit: Move to nodejs-npm SRPM dependency

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -9,7 +9,7 @@ copy_upstream_release_description: true
 
 srpm_build_deps:
 - make
-- npm
+- nodejs-npm
 
 actions:
   post-upstream-clone: make cockpit-ostree.spec


### PR DESCRIPTION
`npm` recently became broken in Fedora and doesn't provide the `npm` binary any more. As a workaround, move to `nodejs-npm` to fix the srpm build.

Cherry-picked from starter-kit commit c499257ec86b3.