### PR TITLE
workflows: Update to ubuntu-latest, set explicit permissions

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -2,11 +2,15 @@ name: cockpit-lib-update
 on:
   schedule:
     - cron: '0 2 * * 4'
-  # can be run manually on https://github.com/cockpit-project/starter-kit/actions
+  # can be run manually on https://github.com/cockpit-project/cockpit-ostree/actions
   workflow_dispatch:
 jobs:
   cockpit-lib-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   npm-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   npm-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -11,7 +11,7 @@ jobs:
     environment: cockpit-ostree-weblate
     permissions:
       pull-requests: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |


### PR DESCRIPTION
Like https://github.com/cockpit-project/starter-kit/pull/643 and https://github.com/cockpit-project/cockpit/pull/18668 . The newer ubuntu platform already got tested in cockpit and starter-kit, and most workflows here already had `permissions:`. 

I added `statuses: write`, as the PO workflows have it, too. I'm not sure that we really need it, but it's harmless enough.

I restricted the default token permissions to read-only now.