### PR TITLE
test: wait before count packages

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -316,12 +316,12 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_prop(b, 2, "Actions", "Roll back and reboot")
         wait_deployment_details_prop(b, 2, "Tree", "#osname", get_name(self))
 
-        check_package_count(b, self.assertIn, 2)
         wait_packages(b, 2, {"down": [tzdata],
                              "up": [chrony],
                              "removes": ["empty-1-0.noarch"],
                              "adds": [remove_pkg],
                              })
+        check_package_count(b, self.assertIn, 2)
 
         # Rollback
         do_deployment_action(b, 2, "Roll back and reboot")


### PR DESCRIPTION
The first deployment we first wait on the packages and then count, apply this here as well.

Not a huge fan of the code around it, but this should resolve the flake.