### PR TITLE
Makefile: prefer running build.js directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(DIST_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type
 	NODE_ENV=$(NODE_ENV) ./build.js
 
 watch: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) ESBUILD_WATCH=true ./build.js
 
 clean:
 	rm -rf dist/


### PR DESCRIPTION
It's not needed to invoke npm, it's also slower then directly invoking `build.js`.