### PR TITLE
package.json: Update to PatternFly 5 final

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = d7126448b1e74e59f75157389225289dc34c3fd5 # 297 + 19 commits
+COCKPIT_REPO_COMMIT = fabdc84bd6bb06454f7b472b523cea06d806cefc # 297 + PF5 final adjustments
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "stylelint-formatter-pretty": "^3.2.0"
   },
   "dependencies": {
-    "@patternfly/patternfly": "5.0.0-prerelease.8",
-    "@patternfly/react-core": "5.0.0-alpha.132",
-    "@patternfly/react-icons": "5.0.0-alpha.21",
-    "@patternfly/react-styles": "5.0.0-alpha.19",
-    "@patternfly/react-table": "5.0.0-alpha.136",
-    "@patternfly/react-tokens": "5.0.0-alpha.16",
+    "@patternfly/patternfly": "5.0.2",
+    "@patternfly/react-core": "5.0.0",
+    "@patternfly/react-icons": "5.0.0",
+    "@patternfly/react-styles": "5.0.0",
+    "@patternfly/react-table": "5.0.0",
+    "@patternfly/react-tokens": "5.0.0",
     "date-fns": "2.30.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/ostree.scss
+++ b/src/ostree.scss
@@ -71,3 +71,9 @@
 .pf-v5-c-form.pf-m-horizontal {
     width: 100%;
 }
+
+// properly align the "change-repo" inline button with the other toolbar items
+// it defaults to --pf-v5-c-button--m-inline--PaddingTop, which is 0
+.pf-v5-c-button.pf-m-link.pf-m-inline {
+    padding-top: var(--pf-v5-c-button--PaddingTop);
+}


### PR DESCRIPTION
This requires a CSS tweak for the "change-repo" button, to stay vertically centered in the toolbar.

[pixel diff review](https://github.com/cockpit-project/pixel-test-reference/compare/81085cab682a0d6b2011763003182ab68dc7e0c5..0358a00c0d21932c9648b06a78060d2e867eac0f)