### PR TITLE
dependabot: Run in our evenings, reduce limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      # run these when most of our developers don't work, don't DoS our CI over the day
+      time: "22:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
     labels:
       - "node_modules"
     groups:


### PR DESCRIPTION
So far the daily updates tend to run in our mornings between 7:00 and 8:00, which blocks our CI for a long time, and thus collides with developers sending PRs. Move them to the evening instead, when they can use the quiet bots time.

Also reduce the number of parallel PRs from 5 to 3. Parallel ones always need to be rebased, and thus are very expensive. We still want to be able to have a complicated PatternFly PR open for several days without blocking other updates.