### PR TITLE
package.json: stylelint: Add logical property checker

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": "stylelint-config-standard-scss",
+  "plugins": [
+	  "stylelint-use-logical-spec"
+  ],
   "rules": {
 	"declaration-colon-newline-after": null,
 	"selector-list-comma-newline-after": null,
@@ -35,6 +38,7 @@
 	"scss/no-global-function-names": null,
 	"scss/operator-no-unspaced": null,
 	"selector-class-pattern": null,
-	"selector-id-pattern": null
+	"selector-id-pattern": null,
+	"liberty/use-logical-spec": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "stylelint": "15.11.0",
     "stylelint-config-standard": "34.0.0",
     "stylelint-config-standard-scss": "11.0.0",
-    "stylelint-formatter-pretty": "3.2.1"
+    "stylelint-formatter-pretty": "3.2.1",
+    "stylelint-use-logical-spec": "5.0.0"
   },
   "dependencies": {
     "@patternfly/patternfly": "5.1.0",

--- a/src/ostree.scss
+++ b/src/ostree.scss
@@ -48,7 +48,7 @@
 
 // PF4 modals have a max height and scroll on overflow - unset the maximum height to avoid getting a scrollbar
 .pf-v5-c-modal-box {
-    max-height: calc(100vh - var(--pf-v5-global--spacer--2xl));
+    max-block-size: calc(100vh - var(--pf-v5-global--spacer--2xl));
 }
 
 // Create space between the remote name and the edit action
@@ -64,16 +64,15 @@
 }
 
 .simple-list-form-actions > .pf-v5-c-button {
-    margin-left: 0.3em;
-    margin-right: 0.3em;
+    margin-inline: 0.3em;
 }
 
 .pf-v5-c-form.pf-m-horizontal {
-    width: 100%;
+    inline-size: 100%;
 }
 
 // properly align the "change-repo" inline button with the other toolbar items
 // it defaults to --pf-v5-c-button--m-inline--PaddingTop, which is 0
 .pf-v5-c-button.pf-m-link.pf-m-inline {
-    padding-top: var(--pf-v5-c-button--PaddingTop);
+    padding-block-start: var(--pf-v5-c-button--PaddingTop);
 }


### PR DESCRIPTION
Auto-fix usage of logical properties. This should help out with RTL as otherwise properties need to be changed from for example padding-left to padding-right.