### PR TITLE
github: allow dependeabot to update github workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,9 @@ updates:
       patternfly:
         patterns:
           - "@patternfly*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Github usually updates their actions once a while and then warns about a node env getting deprecated in runs. Which is not super easily spotted by a developer until it's too late, so let's like npm let dependabot handle updating.