### PR TITLE
test: Increase timeout for reset dialog

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -540,7 +540,8 @@ class OstreeRestartCase(testlib.MachineCase):
         b.wait_visible("#reset-modal")
         b.click("#remove-overlays-checkbox")
         b.click("#reset-modal button.pf-m-warning")
-        b.wait_not_present("#reset-modal")
+        with b.wait_timeout(60):
+            b.wait_not_present("#reset-modal")
 
         wait_deployment_details_prop(b, 1, "Packages", ".removes", "Removalsempty-1-0.noarch")
 


### PR DESCRIPTION
This can legitimately take a while.

--

Should fix [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-530-20240227-180853-9902a5a3-rhel4edge/log.html#4-1)