### PR TITLE
lint: Ignore test functions in vulture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,10 @@ select = [
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020
 ]
+
+[tool.vulture]
+ignore_names = [
+   "test[A-Z0-9]*",
+   "OstreeCase",
+   "OstreeRestartCase",
+]


### PR DESCRIPTION
These aren't unused, but discovered/enumerated by `unittest` or `pytest`.