### PR TITLE
Show OCI container origin

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,6 @@
 import cockpit from 'cockpit';
+
+import { logDebug } from './utils.js';
 const _ = cockpit.gettext;
 
 const DEST = 'org.projectatomic.rpmostree1';
@@ -309,8 +311,14 @@ class RPMOSTreeDBusClient {
 
         if (proxy) {
             origin = proxy.BootedDeployment?.origin?.v;
-            if (!origin)
+            if (origin) {
+                logDebug("get_os_origin", os, "from BootedDeployment", origin);
+            } else {
                 origin = proxy.DefaultDeployment?.origin?.v;
+                logDebug("get_os_origin", os, "from DefaultDeployment", origin);
+            }
+        } else {
+            logDebug("get_os_origin", os, "no proxy");
         }
 
         return origin;
@@ -386,6 +394,7 @@ class RPMOSTreeDBusClient {
             }
         }
 
+        logDebug(`known_versions_for osname '${os_name}' remote '${remote}' branch '${branch}':`, list);
         return list;
     }
 

--- a/src/ostree.jsx
+++ b/src/ostree.jsx
@@ -206,19 +206,19 @@ const TreeDetails = ({ info }) => {
         <DescriptionList isHorizontal>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Operating system") }</DescriptionListTerm>
-                <DescriptionListDescription className="os" id="osname">{info.osname.v}</DescriptionListDescription>
+                <DescriptionListDescription className="os">{info.osname.v}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Version") }</DescriptionListTerm>
-                <DescriptionListDescription className="version" id="osversion">{info.version?.v}</DescriptionListDescription>
+                <DescriptionListDescription className="version">{info.version?.v}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Released") }</DescriptionListTerm>
-                <DescriptionListDescription className="timestamp" id="osrelease">{timeformat.distanceToNow(info.timestamp.v * 1000, true)}</DescriptionListDescription>
+                <DescriptionListDescription className="timestamp">{timeformat.distanceToNow(info.timestamp.v * 1000, true)}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
                 <DescriptionListTerm>{ _("Origin") }</DescriptionListTerm>
-                <DescriptionListDescription className="origin" id="osorigin">{info.origin?.v}</DescriptionListDescription>
+                <DescriptionListDescription className="origin">{info.origin?.v}</DescriptionListDescription>
             </DescriptionListGroup>
         </DescriptionList>
     );

--- a/src/ostree.jsx
+++ b/src/ostree.jsx
@@ -62,6 +62,7 @@ import { AddRepositoryModal, EditRepositoryModal, RebaseRepositoryModal, RemoveR
 import './ostree.scss';
 import { CleanUpModal, ResetModal } from './deploymentModals';
 import { WithDialogs, DialogsContext, useDialogs } from "dialogs.jsx";
+import { logDebug } from './utils.js';
 
 const _ = cockpit.gettext;
 
@@ -743,6 +744,7 @@ class Application extends React.Component {
             } else {
                 let newState;
                 if (!this.state.origin.remote) {
+                    logDebug('check_empty: no current origin, detecting from os_list', client.os_list);
                     const os = client.os_list[0];
                     const origin = client.get_default_origin(os) || {};
                     newState = {
@@ -849,15 +851,19 @@ class Application extends React.Component {
 
     updateBranches(remote) {
         if (!remote) {
+            logDebug('updateBranches: no remote');
             return;
         }
 
         return remotes.listBranches(remote)
                 .then(branches => {
+                    logDebug('updateBranches: branches=', branches);
                     const update = { branches, branchLoadError: null };
                     // if current branch does not exist, change to the first listed branch
-                    if (branches.indexOf(this.state.origin.branch) < 0)
+                    if (branches.indexOf(this.state.origin.branch) < 0) {
                         update.origin = { remote: this.state.origin.remote, branch: branches[0] };
+                        logDebug('updateBranches: setting origin to first listed branch:', update.origin);
+                    }
                     this.setState(update);
                     return branches;
                 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,11 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+export function logDebug(...args) {
+    if (window.debugging === "all" || window.debugging?.includes("ostree"))
+        console.debug('ostree:', ...args);
+}
+
 const configRegex = {
     /* section headers, ei: [section] */
     section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -198,8 +198,8 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_prop(b, 1, "Status", "Current")
         wait_deployment_prop(b, 1, "Actions", "")
 
-        wait_deployment_details_prop(b, 1, "Tree", "#osname", get_name(self))
-        wait_deployment_details_prop(b, 1, "Tree", "#osversion", "cockpit-base.1")
+        wait_deployment_details_prop(b, 1, "Tree", ".os", get_name(self))
+        wait_deployment_details_prop(b, 1, "Tree", ".version", "cockpit-base.1")
 
         b.assert_pixels("#ostree-status", "status")
         b.assert_pixels("#ostree-source", "source")
@@ -219,7 +219,7 @@ class OstreeRestartCase(testlib.MachineCase):
 
         b.wait_not_in_text("#available-deployments > tbody:nth-child(3) td[data-label=Version]", "cockpit")
         wait_deployment_prop(b, 2, "Actions", "Roll back")
-        wait_deployment_details_prop(b, 2, "Tree", "#osname", get_name(self))
+        wait_deployment_details_prop(b, 2, "Tree", ".os", get_name(self))
 
         # Check for new commit, get error
         b.click("#check-for-updates-btn")
@@ -253,8 +253,8 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_prop(b, 2, "Status", "Current")
 
         # Check update data
-        wait_deployment_details_prop(b, 1, "Tree", "#osname", get_name(self))
-        wait_deployment_details_prop(b, 1, "Tree", "#osversion", "cockpit-base.2")
+        wait_deployment_details_prop(b, 1, "Tree", ".os", get_name(self))
+        wait_deployment_details_prop(b, 1, "Tree", ".version", "cockpit-base.2")
 
         wait_packages(b, 1, {"up": ["tzdata-99999-2.noarch"],
                              "down": ["chrony-0.1-2.noarch"],
@@ -318,7 +318,7 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_prop(b, 2, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 2, "Actions", "Roll back")
         wait_deployment_prop(b, 2, "Status", "")
-        wait_deployment_details_prop(b, 2, "Tree", "#osname", get_name(self))
+        wait_deployment_details_prop(b, 2, "Tree", ".os", get_name(self))
 
         wait_packages(b, 2, {"down": [tzdata],
                              "up": [chrony],
@@ -391,15 +391,15 @@ class OstreeRestartCase(testlib.MachineCase):
         b.wait_in_text("#current-branch", "znew-branch")
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "Current")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", f"local:{branch}")
 
         b.click("#check-for-updates-btn")
 
         wait_deployment_prop(b, 1, "Version", "branch-version")
         wait_deployment_prop(b, 1, "Status", "New")
         wait_deployment_prop(b, 1, "Actions", "Rebase")
-        wait_deployment_details_prop(b, 1, "Tree", "#osname", get_name(self))
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", "local:znew-branch")
+        wait_deployment_details_prop(b, 1, "Tree", ".os", get_name(self))
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", "local:znew-branch")
 
         # Apply update
         do_deployment_action(b, 1, "Rebase")
@@ -418,7 +418,7 @@ class OstreeRestartCase(testlib.MachineCase):
         # After reboot, check commit
         wait_deployment_prop(b, 1, "Version", "branch-version")
         wait_deployment_prop(b, 1, "Status", "Current")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", "local:znew-branch")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", "local:znew-branch")
 
         self.allow_restart_journal_messages()
 
@@ -446,7 +446,7 @@ class OstreeRestartCase(testlib.MachineCase):
         # our image defaults to local OSTree repo
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "Current")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", f"local:{branch}")
         wait_packages(b, 1, {"rpms-col1": [bash_ver]})
 
         # rebase to our OCI repo
@@ -457,14 +457,14 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "")
         # OCI deployments have no origin
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", "")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", "")
         wait_deployment_details_prop(b, 1, "Packages", ".same-packages",
                                      "This deployment contains the same packages as your currently booted system")
 
         # current deployment is now second
         wait_deployment_prop(b, 2, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 2, "Status", "Current")
-        wait_deployment_details_prop(b, 2, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 2, "Tree", ".origin", f"local:{branch}")
         wait_packages(b, 2, {"rpms-col1": [bash_ver]})
 
         # podman sometimes leaves the container behind after reboot despite --rm
@@ -478,12 +478,12 @@ class OstreeRestartCase(testlib.MachineCase):
         # now the status is reversed: OCI deployment is running and has the package list
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "Current")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", "")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", "")
         wait_packages(b, 1, {"rpms-col1": [bash_ver]})
         # ... and second deployment is the ostree repo one
         wait_deployment_prop(b, 2, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 2, "Status", "")
-        wait_deployment_details_prop(b, 2, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 2, "Tree", ".origin", f"local:{branch}")
         wait_deployment_details_prop(b, 2, "Packages", ".same-packages",
                                      "This deployment contains the same packages as your currently booted system")
 
@@ -743,15 +743,15 @@ class OstreeCase(testlib.MachineCase):
 
         # Check updates display
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", f"local:{branch}")
 
         b.click("#check-for-updates-btn")
 
         wait_deployment_prop(b, 1, "Version", "zremote-branch1.1")
         wait_deployment_prop(b, 1, "Status", "New")
         wait_deployment_prop(b, 1, "Actions", "Rebase")
-        wait_deployment_details_prop(b, 1, "Tree", "#osname", get_name(self))
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", "zremote-test1:zremote-branch1")
+        wait_deployment_details_prop(b, 1, "Tree", ".os", get_name(self))
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", "zremote-test1:zremote-branch1")
 
         wait_deployment_details_prop(b, 1, "Packages", ".same-packages",
                                      "This deployment contains the same packages as your currently booted system")
@@ -836,7 +836,7 @@ class OstreeCase(testlib.MachineCase):
         b.wait_in_text("#current-branch", branch)
         wait_deployment_prop(b, 1, "Version", "bad-version")
         wait_deployment_prop(b, 1, "Status", "New")
-        wait_deployment_details_prop(b, 1, "Tree", "#osorigin", f"local:{branch}")
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", f"local:{branch}")
 
     @testlib.nondestructive
     def testPermission(self):

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -440,10 +440,15 @@ class OstreeRestartCase(testlib.MachineCase):
 
         # start our local registry
         self.start_oci_registry()
+        oci_repo = "ostree-unverified-registry:localhost:5000/ostree-oci"
+        oci_branch = "cockpit1"
+        oci_repo_branch = f"{oci_repo}:{oci_branch}"
 
         self.login_and_go("/updates")
 
         # our image defaults to local OSTree repo
+        b.wait_text("#current-repository .pf-v5-c-description-list__description", "local")
+        b.wait_text("#current-branch .pf-v5-c-description-list__description", branch)
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "Current")
         wait_deployment_details_prop(b, 1, "Tree", ".origin", f"local:{branch}")
@@ -451,13 +456,13 @@ class OstreeRestartCase(testlib.MachineCase):
 
         # rebase to our OCI repo
         # FIXME: there is currently no UI way of doing this
-        m.execute("rpm-ostree rebase ostree-unverified-registry:localhost:5000/ostree-oci:cockpit1")
+        m.execute(f"rpm-ostree rebase {oci_repo_branch}")
 
         # UI picks this up
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "")
-        # OCI deployments have no origin
-        wait_deployment_details_prop(b, 1, "Tree", ".origin", "")
+        wait_deployment_prop(b, 1, "Branch", oci_repo_branch)
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", oci_repo_branch)
         wait_deployment_details_prop(b, 1, "Packages", ".same-packages",
                                      "This deployment contains the same packages as your currently booted system")
 
@@ -475,10 +480,15 @@ class OstreeRestartCase(testlib.MachineCase):
         self.start_oci_registry()
         self.login_and_go("/updates")
 
+        # OCI is now the current deployment
+        b.wait_text("#current-repository .pf-v5-c-description-list__description", oci_repo)
+        b.wait_text("#current-branch .pf-v5-c-description-list__description", oci_branch)
+
         # now the status is reversed: OCI deployment is running and has the package list
         wait_deployment_prop(b, 1, "Version", "cockpit-base.1")
         wait_deployment_prop(b, 1, "Status", "Current")
-        wait_deployment_details_prop(b, 1, "Tree", ".origin", "")
+        wait_deployment_prop(b, 1, "Branch", oci_repo_branch)
+        wait_deployment_details_prop(b, 1, "Tree", ".origin", oci_repo_branch)
         wait_packages(b, 1, {"rpms-col1": [bash_ver]})
         # ... and second deployment is the ostree repo one
         wait_deployment_prop(b, 2, "Version", "cockpit-base.1")


### PR DESCRIPTION
The rpm-ostree API has these in a `container-image-reference` field for
deployments and versions. In the UI we want to show them the same way as
"classic" OSTree repository origins.

Fix `get_default_origin()` to consider the *last* colon-separated
component as the branch name, instead of all but the first. OCI
repositories contain other colons (ate least the schema, and possibly
a registry domain port).

----


On current main, all the "OSTree source" and "Branch" and "Origin" fields are empty. Now they show the OCI repo:

![image](https://github.com/cockpit-project/cockpit-ostree/assets/200109/d4607884-c69e-4d60-8337-c741b56b9167)

## ostree: Show OCI container origin

cockpit-ostree now detects and shows the origin, repository, and branch name of [native container repositories](https://coreos.github.io/rpm-ostree/container/).

TODO: screenshot with "real" Fedora source