### PR TITLE
eslint: enable no-useless-fragment rule by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
         "react/jsx-first-prop-new-line": "off",
         "react/jsx-curly-newline": "off",
         "react/jsx-handler-names": "off",
+        "react/jsx-no-useless-fragment": "error",
         "react/prop-types": "off",
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",


### PR DESCRIPTION
This rule is not part of the standard ESLint recommends set but is useful and can be auto-fixed.