### PR TITLE
dependabot: Group React and types packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,15 +17,22 @@ updates:
       esbuild:
         patterns:
           - "esbuild*"
+      patternfly:
+        patterns:
+          - "@patternfly*"
+      react:
+        patterns:
+          - "react*"
       stylelint:
         patterns:
           - "stylelint*"
       xterm:
         patterns:
           - "xterm*"
-      patternfly:
+      types:
         patterns:
-          - "@patternfly*"
+          - "@types*"
+          - "types*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Also sort the list alphabetically.

---

See #592 and #593, these shouldn't be updated individually.