### PR TITLE
dependabot: Dial down to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-      # run these when most of our developers don't work, don't DoS our CI over the day
-      time: "22:00"
+      interval: "weekly"
+      # run these when most of our developers don't work
+      day: "sunday"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 3
     labels:
@@ -26,13 +26,13 @@ updates:
       stylelint:
         patterns:
           - "stylelint*"
-      xterm:
-        patterns:
-          - "xterm*"
       types:
         patterns:
           - "@types*"
           - "types*"
+      xterm:
+        patterns:
+          - "xterm*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This creates a lot of pilot and CI churn, and structurally we are not affected by most security flaws in our runtime dependencies.

So let's try a weekly schedule instead. Run them on Sundays, so that they are ready to inspect on Mondays.

Also sort the pattern list, to reduce the diff with our other projects.