### PR TITLE
Makefile: run xgettext on typescript sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ po/$(PACKAGE_NAME).js.pot:
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
+		--from-code=UTF-8 $$(find src/ -name '*.[jt]s' -o -name '*.[jt]sx')
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
 	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')


### PR DESCRIPTION
We currently only extract translations from .js and .jsx files.  Make sure we also include .ts and .tsx.