### PR TITLE
build.js: support outputting esbuild metadata file

### DIFF
--- a/build.js
+++ b/build.js
@@ -26,6 +26,7 @@ const packageJson = JSON.parse(fs.readFileSync('package.json'));
 const parser = (await import('argparse')).default.ArgumentParser();
 parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
 parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode", default: process.env.ESBUILD_WATCH === "true" });
+parser.add_argument('-m', '--metafile', { help: "Enable bundle size information file", metavar: "FILE" });
 const args = parser.parse_args();
 
 if (args.rsync)
@@ -82,6 +83,7 @@ const context = await esbuild.context({
     external: ['*.woff', '*.woff2', '*.jpg', '*.svg', '../../assets*'], // Allow external font files which live in ../../static/fonts
     legalComments: 'external', // Move all legal comments to a .LEGAL.txt file
     loader: { ".js": "jsx" },
+    metafile: !!args.metafile,
     minify: production,
     nodePaths,
     outdir,
@@ -118,7 +120,10 @@ if (args.watch) {
         await context.cancel();
 
         try {
-            await context.rebuild();
+            const result = await context.rebuild();
+            if (args.metafile) {
+                fs.writeFileSync(args.metafile, JSON.stringify(result.metafile));
+            }
         } catch (e) {} // ignore in watch mode
     };
 


### PR DESCRIPTION
ESbuild supports outputting a metadata file which can be used to view bundle size information using https://esbuild.github.io/analyze/