### PR TITLE
eslint: configure import sorting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,16 @@
                 "MemberExpression": 2,
                 "ignoredNodes": [ "JSXAttribute" ]
             }],
+        "import/order": ["error",
+            {
+                "alphabetize": { "order": "asc" },
+                "groups": ["builtin", "external", "internal", "parent", "sibling"],
+                "newlines-between": "always",
+                "pathGroupsExcludedImportTypes": ["react"],
+                "pathGroups": [
+                    { "pattern": "react", "group": "builtin", "position": "before" }
+                ]
+            }],
         "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
         "no-var": "error",
         "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
@@ -52,5 +62,10 @@
     "globals": {
         "require": "readonly",
         "module": "readonly"
+    },
+    "settings": {
+        "import/resolver": {
+            "node": { "moduleDirectory": [ "pkg/lib" ], "extensions": [ ".js", ".jsx", ".ts", ".tsx" ] }
+        }
     }
 }

--- a/build.js
+++ b/build.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
-import path from 'node:path';
 import os from 'node:os';
+import path from 'node:path';
 
 import copy from 'esbuild-plugin-copy';
 
-import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
-import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
 import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
+import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
 import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
+import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 
 const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild')).default;

--- a/src/deploymentModals.jsx
+++ b/src/deploymentModals.jsx
@@ -19,17 +19,17 @@
 
 import React, { useState } from 'react';
 
-import cockpit from 'cockpit';
-import client from './client';
-
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox';
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
-import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { Text } from "@patternfly/react-core/dist/esm/components/Text";
-
+import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { useDialogs } from "dialogs.jsx";
+
+import cockpit from 'cockpit';
+
+import client from './client';
 
 const _ = cockpit.gettext;
 

--- a/src/ostree.jsx
+++ b/src/ostree.jsx
@@ -20,23 +20,20 @@
 import 'cockpit-dark-theme'; // once per page
 
 import React, { useState } from 'react';
-import { createRoot } from 'react-dom/client';
-import PropTypes from "prop-types";
-import { debounce } from 'throttle-debounce';
+
+import { createRoot } from 'react-dom/client'; // eslint-disable-line import/order
 
 import 'patternfly/patternfly-5-cockpit.scss';
 
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Card, CardHeader, CardTitle, CardBody } from "@patternfly/react-core/dist/esm/components/Card";
-import { EmptyState, EmptyStateIcon, EmptyStateBody, EmptyStateHeader, EmptyStateFooter, EmptyStateVariant } from "@patternfly/react-core/dist/esm/components/EmptyState";
-import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
-import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
-import { DropdownItem } from "@patternfly/react-core/dist/esm/components/Dropdown";
 import {
     DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription
 } from "@patternfly/react-core/dist/esm/components/DescriptionList";
-import { Gallery, } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
+import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
+import { DropdownItem } from "@patternfly/react-core/dist/esm/components/Dropdown";
+import { EmptyState, EmptyStateIcon, EmptyStateBody, EmptyStateHeader, EmptyStateFooter, EmptyStateVariant } from "@patternfly/react-core/dist/esm/components/EmptyState";
 import { Label, } from "@patternfly/react-core/dist/esm/components/Label";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
@@ -44,25 +41,27 @@ import { Page, PageSection, } from "@patternfly/react-core/dist/esm/components/P
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner";
 import { Text } from "@patternfly/react-core/dist/esm/components/Text";
-
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Gallery, } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { BugIcon, CheckIcon, ExclamationCircleIcon, ExclamationTriangleIcon, PendingIcon, ErrorCircleOIcon, CheckCircleIcon, SyncAltIcon } from '@patternfly/react-icons';
+import { KebabDropdown } from 'cockpit-components-dropdown.jsx';
+import { WithDialogs, DialogsContext, useDialogs } from "dialogs.jsx";
+import PropTypes from "prop-types";
+import { debounce } from 'throttle-debounce';
 
 import cockpit from 'cockpit';
-
-import * as timeformat from 'timeformat';
-import { superuser } from 'superuser';
-import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
-import { KebabDropdown } from 'cockpit-components-dropdown.jsx';
+import { ListingTable } from "cockpit-components-table.jsx";
+import { superuser } from 'superuser';
+import * as timeformat from 'timeformat';
 
 import client from './client';
+import { CleanUpModal, ResetModal } from './deploymentModals';
 import * as remotes from './remotes';
 import { AddRepositoryModal, EditRepositoryModal, RebaseRepositoryModal, RemoveRepositoryModal } from './repositoryModals.jsx';
+import { logDebug } from './utils.js';
 
 import './ostree.scss';
-import { CleanUpModal, ResetModal } from './deploymentModals';
-import { WithDialogs, DialogsContext, useDialogs } from "dialogs.jsx";
-import { logDebug } from './utils.js';
 
 const _ = cockpit.gettext;
 

--- a/src/remotes.js
+++ b/src/remotes.js
@@ -18,6 +18,7 @@
  */
 
 import cockpit from 'cockpit';
+
 import client from './client.js';
 import { parseData, changeData } from './utils.js';
 

--- a/src/repositoryModals.jsx
+++ b/src/repositoryModals.jsx
@@ -18,26 +18,25 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import PropTypes from "prop-types";
-
-import cockpit from 'cockpit';
 
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox';
-import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
-import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
-import { Text } from "@patternfly/react-core/dist/esm/components/Text";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
-import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea";
-import { Select, SelectList, SelectOption } from "@patternfly/react-core/dist/esm/components/Select";
 import { MenuToggle } from "@patternfly/react-core/dist/esm/components/MenuToggle";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Select, SelectList, SelectOption } from "@patternfly/react-core/dist/esm/components/Select";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
+import { Text } from "@patternfly/react-core/dist/esm/components/Text";
+import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-
 import { FormHelper } from 'cockpit-components-form-helper.jsx';
 import { useDialogs } from "dialogs.jsx";
+import PropTypes from "prop-types";
+
+import cockpit from 'cockpit';
 
 import * as remotes from './remotes';
 

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -18,6 +18,7 @@
  */
 
 import QUnit from 'qunit';
+
 import * as utils from './utils.js';
 
 const sample_config = `


### PR DESCRIPTION
This more or less enforces existing practice, but cleans up many places where we've deviated from that.  We sort into these groups:

- 'react', if present, always first
- external (`node_modules/`) imports
- cockpitlib (`pkg/lib/`) imports
- parent (`../`) imports
- sibling (`./`) imports