### PR TITLE
package.json: Explicitly depend on stylelint-config-recommended-scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sass": "1.77.6",
     "sizzle": "2.3.10",
     "stylelint": "16.6.1",
+    "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-config-standard": "36.0.1",
     "stylelint-config-standard-scss": "13.1.0",
     "stylelint-formatter-pretty": "4.0.0",


### PR DESCRIPTION
The latest version 14.1.0 does not work with our other stylelint package versions. Pin down the version we've used so far, and let dependabot take care of grouped updates.

---

Fixes [this spontaneous breakage](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6598-f4894eed-20240709-224704-fedora-coreos-devel-cockpit-project-cockpit-ostree/log.html)