### PR TITLE
build: don't rely on implicitly imported process

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 
 import copy from 'esbuild-plugin-copy';
 


### PR DESCRIPTION
This was fixed in Cockpit in cf1cca4166af4c59531850a8e0d0f20f6f455152