### PR TITLE
test: Hack around rpm-ostreed's unstoppable suicide

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -893,6 +893,11 @@ class OstreeOCICase(testlib.MachineCase):
         if m.image.endswith("-bootc"):
             # this works with rpm-ostree as well, but let's use the future designated CLI
             m.execute(f"bootc switch localhost:5000/bootc:{new_branch}")
+
+            # HACK: rpm-ostreed hard-timeouts in a crash-like manner after a minute, with no
+            # obvious way to keep it alive; https://issues.redhat.com/browse/RHEL-49603
+            b.reload()
+            b.enter_page("/updates")
         else:
             m.execute(f"rpm-ostree rebase {new_repo_branch}")
 


### PR DESCRIPTION
Current rpm-ostreed exits after its configured `IdleExitTimeout` (default one minute), regardless of how many connections it has or when the last request happened [1]. It also doesn't properly unregister from D-Bus when it exists. So there is no way to properly work around that for us: we can neither send it keep-alive pings/requests nor react to `close` messages (not even when we enable the `track: true` option).

The `bootc switch` call in our test is quite expensive and takes around a minute. rpm-ostreed often times out while that's running, so that from then on the UI will never update any more as it does not receive any signals any more.

Hack around that by reloading the page after the call, to get a fresh connection and updated UI.

[1] https://issues.redhat.com/browse/RHEL-49603

---

This blocks https://github.com/cockpit-project/bots/pull/6630 . I triggered an extra test against that new image. I also confirmed that the test is reliable now with the extra "sleep 20". See https://github.com/cockpit-project/bots/pull/6630#issuecomment-2236237825 for the debugging details.