### PR TITLE
test: Move from CDP to BiDi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 07fddba43934fb256ec8da03812f081eab3baa18 # 321 + 117 commits
+COCKPIT_REPO_COMMIT = 83e1a5ac16d8eb8df60f90c8fa502a0d8bf21365 # 322 + 35 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "argparse": "2.0.1",
     "bootstrap-sass": "3.4.3",
-    "chrome-remote-interface": "0.33.2",
     "esbuild": "0.23.0",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-replace": "1.4.0",
@@ -35,6 +34,7 @@
     "eslint-plugin-react": "7.35.0",
     "eslint-plugin-react-hooks": "4.6.2",
     "gettext-parser": "8.0.0",
+    "glob": "11.0.0",
     "htmlparser": "1.7.7",
     "jed": "1.1.1",
     "qunit": "2.21.1",


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/pull/20832

Explicitly add a "glob" devDependency to follow suit with https://github.com/cockpit-project/cockpit/commit/680decc155a It was previously used implicitly through a transient dependency of something else, but our esbuild po-plugin uses it explicitly.

 - [x] https://github.com/cockpit-project/cockpit/pull/20883