### PR TITLE
Use rpm-ostree's RegisterClient() method for stopping suicide

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -176,6 +176,11 @@ class RPMOSTreeDBusClient {
             this.sysroot.addEventListener("changed", this.on_sysroot_changed);
             this.sysroot.wait(() => {
                 if (this.client) {
+                    /* HACK: by default, rpm-ostreed's IdleTimeout is way too aggressive and broken
+                    * Tell it to not do that */
+                    this.sysroot.RegisterClient({ id: cockpit.variant("s", "cockpit-ostree") })
+                            .catch(ex => console.error("Failed to register client:", JSON.stringify(ex)));
+
                     this.os_proxies = this.client.proxies(OS, PATH);
                     this.os_proxies_added = (event, proxy) => {
                         if (proxy.Name)

--- a/test/check-ostree
+++ b/test/check-ostree
@@ -878,11 +878,6 @@ class OstreeOCICase(testlib.MachineCase):
         if m.image.endswith("-bootc"):
             # this works with rpm-ostree as well, but let's use the future designated CLI
             m.execute(f"bootc switch localhost:5000/bootc:{new_branch}")
-
-            # HACK: rpm-ostreed hard-timeouts in a crash-like manner after a minute, with no
-            # obvious way to keep it alive; https://issues.redhat.com/browse/RHEL-49603
-            b.reload()
-            b.enter_page("/updates")
         else:
             m.execute(f"rpm-ostree rebase {new_repo_branch}")
 


### PR DESCRIPTION
This is a better workaroud for
https://issues.redhat.com/browse/RHEL-49603
than the hack commit e20543c79575e042b284. Revert the latter.

---

I tested this locally with `ExitIdleTimeout=10`. I just don't want to do that in the VM setup, and rather keep the default config.