### PR TITLE
test: wait for RTL layout changes to settle

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -206,7 +206,7 @@ class OstreeRestartCase(testlib.MachineCase):
         wait_deployment_details_prop(b, 1, TAB_TREE, ".os", get_name(self))
         wait_deployment_details_prop(b, 1, TAB_TREE, ".version", "cockpit-base.1")
 
-        b.assert_pixels("#ostree-status", "status")
+        b.assert_pixels("#ostree-status", "status", wait_after_layout_change=True)
         b.assert_pixels("#ostree-source", "source")
         b.assert_pixels("#available-deployments > tbody:nth-of-type(1)", "deployment",
                         ignore=[".timestamp",


### PR DESCRIPTION
Works around the flaky RTL test, see also https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-ostree