### PR TITLE
spec: Do not build on ix86

### DIFF
--- a/cockpit-ostree.spec.in
+++ b/cockpit-ostree.spec.in
@@ -12,6 +12,10 @@ Requires: rpm-ostree
 
 Source: https://github.com/cockpit-project/%{name}/releases/download/%{version}/cockpit-ostree-%{version}.tar.xz
 
+%if 0%{?fedora} >= 41 || 0%{?rhel}
+ExcludeArch: %{ix86}
+%endif
+
 %define debug_package %{nil}
 
 %description


### PR DESCRIPTION
cockpit-ostree is one of the dependents of rpm-ostree. We are removing i686 buids on this pkg from fedora version 41 and above.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1716#issuecomment-2358745869

---

Originally submitted here: https://src.fedoraproject.org/rpms/cockpit-ostree/pull-request/52