### PR TITLE
test: More precise bootc check

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -20,7 +20,7 @@ else
     rpm2archive /tmp/cockpit-ostree-*.rpm | tar -C / --transform 's,/usr/,/usr/local/,' -xzv
 fi
 
-if bootc status >/dev/null; then
+if bootc status --json | jq .status.booted.image | grep -q version; then
     # for bootc, create a "cockpit1" tag with a removed package, so that we can tell apart the versions in the UI
     podman run -d --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry/:/var/lib/registry localhost/test-registry
     printf 'FROM localhost:5000/bootc:latest\nRUN rpm -e --verbose less' | podman build -t localhost:5000/bootc:cockpit1 -


### PR DESCRIPTION
The latest Fedora CoreOS image [1] adds the `bootc` package by default,
but it's not actually booted with bootc:

```
No staged image present
Current booted image: localhost/bootc:latest
    Image version: stream9.20241108.0 (2024-11-09 22:42:18.512463512 UTC)
    Image digest: sha256:7e1298b4888321b4ce4b497a2db0f9786e701cc1435957501049ef80194bba1d
No rollback image present
```

So query for the currently booted bootc image, like `bootc status --help`
suggests.

[1] https://github.com/cockpit-project/bots/pull/7103
