### PR TITLE
package.json: drop bootstrap-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "argparse": "2.0.1",
-    "bootstrap-sass": "3.4.3",
     "esbuild": "0.24.2",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-replace": "1.4.0",


### PR DESCRIPTION
The ostree plugin doesn't use bootstrap anymore since the React/PF4 rewrite in 2020.