### PR TITLE
Updates for new fedora-coreos image

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -167,8 +167,6 @@ def generate_new_commit(m, pkg_to_remove):
 
 
 def get_name(self):
-    if self.image == "rhel4edge":
-        return "rhel-edge"
     return "fedora-coreos"
 
 
@@ -829,7 +827,6 @@ class OstreeCase(testlib.MachineCase):
         b.wait_in_text("#page_status_notification_updates", f"{get_name(self)} cockpit-base.2")
 
 
-@testlib.skipImage("using image-builder workflow", "rhel4edge")
 class OstreeOCICase(testlib.MachineCase):
     def start_oci_registry(self):
         self.machine.execute(

--- a/test/vm.install
+++ b/test/vm.install
@@ -47,18 +47,16 @@ else
     # build an OCI image from our local repository; ouput to a local registry,
     # as rpm-ostree does not support a local podman image, and using a registry is the realistic use case
     # use the same registry volume as bots/images/scripts/bootc.setup
-    if [ "${branch%fedora*}" != "$branch" ]; then
-        mkdir /var/lib/cockpit-test-registry
-        chcon -t container_file_t /var/lib/cockpit-test-registry/
-        podman run -d --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry/:/var/lib/registry localhost/test-registry
-        mv /etc/containers/registries.conf /etc/containers/registries.conf.orig
-        printf '[registries.insecure]\nregistries = ["localhost:5000"]\n' > /etc/containers/registries.conf
-        rpm-ostree compose container-encapsulate \
-            --repo=/var/local-repo \
-            --label ostree.bootable=true \
-            $branch registry:localhost:5000/ostree-oci:cockpit1
-        podman rm --force --time 0 ostree-registry
-    fi
+    mkdir /var/lib/cockpit-test-registry
+    chcon -t container_file_t /var/lib/cockpit-test-registry/
+    podman run -d --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry/:/var/lib/registry localhost/test-registry
+    mv /etc/containers/registries.conf /etc/containers/registries.conf.orig
+    printf '[registries.insecure]\nregistries = ["localhost:5000"]\n' > /etc/containers/registries.conf
+    rpm-ostree compose container-encapsulate \
+        --repo=/var/local-repo \
+        --label ostree.bootable=true \
+        $branch registry:localhost:5000/ostree-oci:cockpit1
+    podman rm --force --time 0 ostree-registry
 
     rpm-ostree status
 fi


### PR DESCRIPTION
New fedora-coreos images will change the branch name from "fedora/x86_64/coreos/testing" to just "testing".

Pixel diffs: https://github.com/cockpit-project/pixel-test-reference/compare/c9a3a3e030b76afa853d2f3e78056af54255b711..f8e6928db5b51c213d53eb0d35c0bc33b799a3a0

- [ ] https://github.com/cockpit-project/bots/pull/7636
- [x] Remove mention of "rhel4edge"
- [x] Update pixels
