### PR TITLE
test: Drop medium layout of "deployment" pixel test

### DIFF
--- a/test/check-ostree
+++ b/test/check-ostree
@@ -206,6 +206,8 @@ class OstreeRestartCase(testlib.MachineCase):
         b.assert_pixels("#ostree-status", "status", wait_after_layout_change=True)
         b.assert_pixels("#ostree-source", "source")
         b.assert_pixels("#available-deployments > tbody:nth-of-type(1)", "deployment",
+                        # unpredictable expander head
+                        skip_layouts=["medium"],
                         ignore=[".timestamp",
                                 # The columns change size dependent on the second deployment's name.
                                 "td[data-label=Name]", "td[data-label=State]", "td[data-label='Time']"])


### PR DESCRIPTION
This keeps being noisy with each fedora-coreos image, and we keep changing it (last time in #880). With this project being on life support, it's not worth spending lots of time figuring this out.

---

After https://github.com/cockpit-project/bots/pull/7938 it now [happened again](https://cockpit-logs.us-east-1.linodeobjects.com/pull-7975-abba3fcb-20250710-053317-fedora-coreos-cockpit-project-cockpit-ostree/log.html) in https://github.com/cockpit-project/bots/pull/7975 .