### PR TITLE
Include branding.css

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link href="ostree.css" rel="stylesheet">
+  <link href="../../static/branding.css" rel="stylesheet" />
 
   <script type="text/javascript" src="ostree.js"></script>
   <script type="text/javascript" src="po.js"></script>


### PR DESCRIPTION
This allows distributors and in the future admins [1] to customize Cockpit's pages via the branding mechanism.
See https://github.com/cockpit-project/cockpit/commit/a2bc632991e

[1] https://github.com/cockpit-project/cockpit/issues/21338