### PR TITLE
test: Update registries.conf format to v2 format

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -51,7 +51,7 @@ else
     chcon -t container_file_t /var/lib/cockpit-test-registry/
     podman run -d --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry/:/var/lib/registry localhost/test-registry
     mv /etc/containers/registries.conf /etc/containers/registries.conf.orig
-    printf '[registries.insecure]\nregistries = ["localhost:5000"]\n' > /etc/containers/registries.conf
+    printf '[[registry]]\n  location = "localhost:5000"\n  insecure = true\n' > /etc/containers/registries.conf
     rpm-ostree compose container-encapsulate \
         --repo=/var/local-repo \
         --label ostree.bootable=true \


### PR DESCRIPTION
Podman 6 dropped support for the v1 format.