### PR TITLE
package.json: Drop esbuild-plugin-replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "argparse": "3.0.0",
     "esbuild": "0.28.2",
     "esbuild-plugin-copy": "2.1.1",
-    "esbuild-plugin-replace": "1.4.0",
     "esbuild-sass-plugin": "3.7.0",
     "esbuild-wasm": "0.28.2",
     "eslint": "8.57.1",


### PR DESCRIPTION
No longer needed since a year ago, esbuild-common.js no longer depends on it. See:

https://github.com/cockpit-project/cockpit/commit/5795ca9e09249192e4329517511795f49c9ae905